### PR TITLE
WIP - Add RevealJS layout and test presentation

### DIFF
--- a/_includes/footer-revealjs.html
+++ b/_includes/footer-revealjs.html
@@ -1,0 +1,7 @@
+<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.8.0/js/reveal.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.8.0/plugin/markdown/marked.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.8.0/plugin/markdown/markdown.min.js"></script>
+
+<script>
+	Reveal.initialize();
+</script>

--- a/_includes/head-revealjs.html
+++ b/_includes/head-revealjs.html
@@ -1,0 +1,13 @@
+<head>
+  {%- if page.lang -%}
+  <title>{{ site.title[page.lang] }}</title>
+  {%- endif -%}
+
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description[page.lang] }}{% endif %}">
+
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.8.0/css/reveal.min.css">
+	<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/reveal.js/3.8.0/css/theme/moon.min.css">
+  <link rel="icon" type="image/ico" href="/ITStrategy/assets/images/favicon.ico">
+</head>

--- a/_layouts/revealjs.html
+++ b/_layouts/revealjs.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html class="no-js" lang="{{ page.lang }}" dir="ltr">
+
+  {% include head-revealjs.html %}
+
+  <body vocab="http://schema.org/" typeof="WebPage">
+
+    <div class="reveal">
+			<div class="slides">
+        {{ content }}
+			</div>
+		</div>
+
+    {% include footer-revealjs.html %}
+
+  </body>
+
+</html>

--- a/_pages/presentation.html
+++ b/_pages/presentation.html
@@ -1,0 +1,31 @@
+---
+layout: revealjs
+permalink: /presentation.html
+---
+
+<section id="markdown-slides" data-markdown="" 
+		 data-separator="^\n---\n$" 
+		 data-separator-vertical="^\n--\n$"
+		 data-separator-notes="^Note:">
+</section>
+
+<script>
+function getUrlVars() {
+    var vars = {};
+    var parts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m,key,value) {
+        vars[key] = value;
+    });
+    return vars;
+}
+
+function getUrlParam(parameter, defaultvalue){
+  var urlparameter = defaultvalue;
+  if(window.location.href.indexOf(parameter) > -1){
+    urlparameter = getUrlVars()[parameter];
+    }
+  return urlparameter;
+}
+
+var markdown = getUrlParam('markdown','.md');
+document.getElementById("markdown-slides").setAttribute("data-markdown", "./presentations/" + markdown); 
+</script>

--- a/_pages/presentation.html
+++ b/_pages/presentation.html
@@ -26,6 +26,6 @@ function getUrlParam(parameter, defaultvalue){
   return urlparameter;
 }
 
-var markdown = getUrlParam('markdown','.md');
+var markdown = getUrlParam('markdown','.md').replace(/\.\./g, "0");;
 document.getElementById("markdown-slides").setAttribute("data-markdown", "./presentations/" + markdown); 
 </script>

--- a/presentations/en/2019-05-28-Working-in-the-Open.md
+++ b/presentations/en/2019-05-28-Working-in-the-Open.md
@@ -59,7 +59,7 @@ Exceptions for privacy, confidentiality, and security.
 
 **All source code must be released under an appropriate open source software license.**
 
-** Share code publicly when appropriate, and when not, share within the GC.**
+**Share code publicly when appropriate, and when not, share within the GC.**
 
 ---
 

--- a/presentations/en/2019-05-28-Working-in-the-Open.md
+++ b/presentations/en/2019-05-28-Working-in-the-Open.md
@@ -1,0 +1,251 @@
+# Working in the Open
+
+PCH CIOB Tech Talk - 2019-05-28
+
+---
+
+## Plan
+
+- GC Policy Direction
+- Best Practices
+- Managing access and contributions
+- Examples
+- Git and DevOps
+
+---
+
+## GC Policy Direction
+
+- Directive on Open Government
+- PCH Mandate Letters
+- Digital Standards
+- Directive on Management on IT
+
+--
+
+### Directive on Open Government
+
+> **Maximize the release of government information and data of business value**
+
+> Support transparency, accountability, citizen engagement, and socio-economic benefits through reuse
+
+Exceptions for privacy, confidentiality, and security.
+
+--
+
+### PCH Mandate Letters
+
+> **Government and its information should be open by default.**
+
+--
+
+### Digital Standards
+
+| | |
+| ------------- | ------------- |
+| Design with users                  | Build in accessibility from the start |
+| Iterate and improve frequently     | Empower staff to deliver better services |
+| **Work in the open by default**    | Be good data stewards |
+| Use open standards and solutions   | Design ethical services |
+| Address security and privacy risks | Collaborate widely |
+
+--
+
+### Directive on Management on IT
+
+#### Users, Data Standards, Open Source Software and Cloud First
+
+> If a custom-built application is the appropriate option, any source code written must be released in an open format.
+
+**All source code must be released under an appropriate open source software license.**
+
+** Share code publicly when appropriate, and when not, share within the GC.**
+
+---
+
+## Best Practices
+
+- Classification of source code
+- Copyright and Licence
+- Source Code Repository
+- Release Early, Release Often
+
+[Open First Whitepaper - Best Practices](https://github.com/canada-ca/Open_First_Whitepaper/blob/master/en/4_Open_Source_Software_Contribution.md#best-practices-for-releasing-open-source-software)
+
+[Guidance for Publishing Open Source Code](https://github.com/canada-ca/open-source-logiciel-libre/blob/master/en/guides/publishing-open-source-code.md)
+
+--
+
+### Classification of source code
+
+The Directive on Departmental Security Management defines a protected asset as one that may qualify for an exemption or exclusion under the Access to Information Act because its disclosure would reasonably be expected to compromise the non-national interest.
+
+> Source code is considered unclassified
+
+--
+
+#### Source code could be protected, if it contained
+
+- Information obtained in confidence
+- Information about federal-provincial affairs, international affairs and defence, law enforcement and investigations, the safety of individuals or the economic interests of Canada
+- Personal information
+- Third party information
+- Advice about certain aspects of operations of government
+- Information that is subject to solicitor-client privilege or to statutory prohibitions
+- Certain types of information held by the Canadian Broadcasting Corporation and Atomic Energy of Canada Limited
+- Confidences of the Queen’s Privy Council for Canada
+
+--
+
+#### Unclassified information only
+
+Only unclassified information can be stored in public SaaS, like GitHub and GitLab.
+
+--
+
+#### Hide Your Secrets
+
+Keep sensitive data such as credentials secure and separate from source code.
+
+Build process adds configurations and credentials.
+
+--
+
+### Copyright - Ownership
+
+> Copyright (c) Her Majesty the Queen in Right of Canada, as represented by the Minister of Canadian Heritage, 2019
+
+All code written while working for PCH.
+
+--
+
+### Licence - Use
+
+#### Distribution of Derivative works
+
+**Permissive**: Can apply any licence (MIT, Apache)
+
+**Reciprocal**: Must apply same licence (GPL)
+
+https://creativecommons.org/choose/
+
+https://choosealicense.com/
+
+--
+
+#### Recommended permissive licences
+
+- MIT
+- Apache 2.0
+
+--
+
+#### Recommended reciprocal licences
+
+- GPL 3.0
+- LGPL 3.0
+- AGPL 3.0
+
+--
+
+### Source Code Repository
+
+#### Recommended public source code repositories are
+
+- [GitLab](https://gitlab.com/)
+- [GitHub](https://github.com/)
+- [Framagit](https://framagit.org/)
+- [Bitbucket](https://bitbucket.org/)
+- [GCcode](https://gccode.ssc-spc.gc.ca/)
+  - Internal to GC only
+
+--
+
+### Release Early, Release Often
+
+Source code should be released as early as possible in the project's life cycle to avoid the overhead of publishing source code late in the process.
+
+The public source code repository should be the single source of truth where active development is being done.
+
+--
+
+#### This should include
+
+- Code changes
+- Bugs and feature requests
+- Discussions
+- Roadmap
+- Documentation
+
+--
+
+#### Community
+
+Building a welcoming community can influence your project's future and reputation.
+
+Provide a positive experience for contributors and make it easy so they keep coming back.
+
+Respond to questions, bugs and merge requests.
+
+--
+
+#### Working in the open will encourage
+
+- Better documentation
+- Cleaner and well-structured code
+- Processes that will allow you to continuously test and deploy changes
+- Clarity around sensitive data that needs to remain protected and how that's achieved
+
+---
+
+## Managing access and contributions
+
+- Organizations
+- Repositories and Branches
+- Merge Requests
+
+---
+
+## Examples
+
+- canada-ca
+- gctools-outilsgc
+- cds-snc
+- Open First Whitepaper
+- Open Resource Exchange
+- digital.canada.ca
+- ..
+
+---
+
+## Git and DevOps
+
+- Git
+- Dockerfiles
+- Kubernetes - Helm Charts
+- Deployment Pipelines
+- Move testing left..
+
+--
+
+### Git Branching
+
+<img src="https://nvie.com/img/git-model@2x.png"/>
+
+--
+
+### Dockerfile
+
+<img src="https://www.blaize.net/wp-content/uploads/2017/05/Dockerfile-632x392.png"/>
+
+--
+
+### Kubernetes - Helm Charts
+
+https://github.com/gctools-outilsgc/Kubernetes-config/blob/master/prod/message/service.yaml
+
+--
+
+### Deployment Pipeline
+
+<img src="https://raw.githubusercontent.com/weaveworks/flux/master/site/images/deployment-pipeline.png"/>


### PR DESCRIPTION
I added a layout for reveal JS with a test presentation in a presentations folder.  It's get everything from CDN so we should be able to use it for all presentations.

I created a page to load presentations. You tell it the one you want in the URL
To test it go to `/ITStrategy/presentation.html?markdown=en/2019-05-28-Working-in-the-Open.md`

It's easy to break so maybe don't merge it yet