### PR TITLE
Link to actual page on Github

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,6 +1,6 @@
     <footer class="footer">
       <div class="container">
-        <span class="text-muted"><a target="_blank" href="https://github.com/sara-sabr/ITStrategy/">{{ site.viewOnGithub[page.lang] }}</a></span>
+        <span class="text-muted"><a target="_blank" href="https://github.com/sara-sabr/ITStrategy/tree/master/{{ page.path }}">{{ site.viewOnGithub[page.lang] }}</a></span>
       </div>
     </footer>
   </div>


### PR DESCRIPTION
Related to #228

This works well for pages but for drawings, timelines also links to the page.

ex.: https://github.com/sara-sabr/ITStrategy/blob/master/_pages/en/digital-identity-timeline.md