### PR TITLE
Various website tweaks

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ description:
   fr: Travailler ouvertement! Nos travaux en cours, liste de documents de références et présentations.
 docsTitle:
   en: Our Documents
-  fr: Nos Documents
+  fr: Nos documents
 home:
   en: Home
   fr: Accueil
@@ -34,7 +34,7 @@ mandate:
   fr: Mandat
 presentations:
   en: Our Presentations
-  fr: Nos Présentations
+  fr: Nos présentations
 pagesAbout:
   en: About us
   fr: À propos de nous
@@ -61,7 +61,7 @@ title:
   fr: Stratégie TI
 viewOnGithub:
   en: View on GitHub
-  fr: Voir sur GitHub
+  fr: Voir dans GitHub
 writtenBy:
   en: Written by
   fr: Écrit par
@@ -70,7 +70,7 @@ lastModified:
   fr: Dernière modification
 blogPosts:
   en: Our Blog Posts
-  fr: Nos Billets
+  fr: Nos billets
 notice:
   en: All work found on this site are ideas and proposals from the IT Strategy team within ESDC. Content here does not represent the official stance of ESDC nor the Government of Canada at large.
   fr: Tous les travaux présentés sur ce site sont des idées et des propositions de l'équipe de la stratégie informatique de EDSC. Le contenu présenté ici ne représente pas la position officielle de EDSC ni celle du gouvernement du Canada en général.

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -11,6 +11,6 @@
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description[page.lang] }}{% endif %}">
 
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css" integrity="sha384-ggOyR0iXCbMQv3Xipma34MD+dH/1fQ784/j6cY/iJTQUOhcWr7x9JvoRxT2MZw1T" crossorigin="anonymous">
-  <link rel="stylesheet" href="/ITStrategy/assets/css/sticky-footer-navbar.css">
+  <link rel="stylesheet" href="/ITStrategy/assets/css/style.css">
   <link rel="icon" type="image/ico" href="/ITStrategy/assets/images/favicon.ico">
 </head>

--- a/_pages/en/home.md
+++ b/_pages/en/home.md
@@ -10,9 +10,9 @@ Welcome to our living workspace! In fact, this is the automatically generated we
 
 As per the notice that can be found throughout our site, the content you will find all around should be considered **work in progress**: there are no guarantees that the ideas, the proposals and even the presentations that we are developing here in the open will make it into production one day.
 
-You can have a look at our working documents [here]({{site.baseurl}}/documents-and-presentations.html).
+You can have a look at our **[Working Documents]({{site.baseurl}}/documents-and-presentations.html)**.
 
-On the other end, we would gladly welcome your ideas and comments in order to continuously improve our work and, in a way, how ESDC offers its services to Canadians! Please [see here](how-to-contribute.html) to find out how you can contribute your ideas.
+On the other end, we would gladly welcome your ideas and comments in order to continuously improve our work and, in a way, how ESDC offers its services to Canadians! Please look at **[how to contribute](how-to-contribute.html)**.
 
 We have set up a few continuous integration (CI) tests in order to keep our content clean but also to showcase how powerful these open collaboration tools can be to maintain a project, whether it is simple text files or source code.
 You can have a look at our [documentation](https://github.com/sara-sabr/ITStrategy/blob/master/CONTRIBUTING.md#instructions) to see how it works!

--- a/_pages/en/references.md
+++ b/_pages/en/references.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Reference Materials
+title: References
 ref: references
 lang: en
 status: posted
 categories: About us
-permalink: /references.html
+permalink: /references-en.html
 ---
 <!-- markdownlint-disable MD025-->
 # {{ page.title }}

--- a/_pages/fr/accueil.md
+++ b/_pages/fr/accueil.md
@@ -10,15 +10,15 @@ Bienvenue dans notre espace de travail! En fait, il s'agit plutôt du site Web g
 
 Selon l'avis qui peut être trouvé un peu partout dans notre site, tout ce que vous trouverez ici doit être considéré comme du travail en cours: il n'y a aucune garantie que les idées, les propositions et même les présentations que nous développons de façon ouverte seront un jour adoptées.
 
-Vous pouvez consulter nos document [ici]({{ site.baseurl }}/comment-contribuer.html).
+Vous pouvez consulter nos **[documents de travail]({{site.baseurl}}/documents-et-presentations.html)**.
 
-D'un autre côté, nous serions heureux de recevoir vos idées et commentaires afin d'améliorer continuellement notre travail et, d'une certaine façon, la façon dont EDSC offre ses services aux Canadiennes et aux Canadiens! [Voir ici](notes-allocution-rétroaction.html) pour mieux comprendre comment vous pouvez contribuer vos idées.
+D'un autre côté, nous serions heureux de recevoir vos idées et commentaires afin d'améliorer continuellement notre travail et, d'une certaine façon, la façon dont EDSC offre ses services aux Canadiennes et aux Canadiens! Voir **[comment contribuer](comment-contribuer.html)**.
 
 Nous avons également mis en place quelques tests d'intégrations continues (CI) afin de garder notre contenu propre, mais aussi de démontrer la puissance de ces outils de collaboration ouverte pour maintenir un projet, qu'il s'agisse de simples fichiers textes ou de code source.
 Vous pouvez visiter notre [documentation](https://github.com/sara-sabr/ITStrategy/blob/master/CONTRIBUTING.md#instructions) pour comprendre comment le tout fonctionne!
 
 Dans le cadre de notre travail, nous rédigerons également des [billets]({{ site.baseurl }}/nos-billets.html) sur divers thèmes visant à partager notre cheminement au cours de nos recherches, la lecture de livres ou simplement la découverte de sujets qui pourraient intéresser l'ensemble du gouvernement.
 
-S'il vous plaît, n'hésitez pas à explorer nos [Enjeux (Issues)](https://github.com/sara-sabr/ITStrategy/issues) et à commencer à échanger avec nous!
+S'il vous plaît, n'hésitez pas à explorer nos [enjeux (Issues)](https://github.com/sara-sabr/ITStrategy/issues) et à commencer à échanger avec nous!
 
 ~ L'équipe Stratégie TI

--- a/_pages/fr/references.md
+++ b/_pages/fr/references.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Matériel de référence
+title: Références
 ref: references
 lang: fr
 status: posted
 categories: "À propos de nous"
-permalink: /références.html
+permalink: /references-fr.html
 ---
 <!-- markdownlint-disable MD025-->
 # {{ page.title }}

--- a/_posts/en/2019-09-12-who-we-are.md
+++ b/_posts/en/2019-09-12-who-we-are.md
@@ -31,7 +31,7 @@ We consider the commonly heard and flippant remark of "you should work in the pr
 We believe in a [culture of learning](../../../enable-learning.html) and the relentless improvement of our services, the GC at large, and ourselves.
 Which is why we all have copies of our favourite books strewn across our desks, many such resources can be found in our [References](../../../references.html).
 
-The public sector today did not look as it did 25 years ago, and this change did not come easily.
+The public sector today does not look as it did 25 years ago, and this change did not come easily.
 Change never does.
 Our advice to all our fellow travellers from throughout the GC is to ensure you are continually learning, educate yourself nonstop, entertain the idea of change outside of your comfort zone, and move forward -- always forward.
 Do not accept that things must always be as they are -- because we know this is not true, especially as the rate of change continually increases in our digital world.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,5 +1,23 @@
-/* Sticky footer styles - https://getbootstrap.com/docs/4.0/examples/sticky-footer-navbar/
--------------------------------------------------- */
+/* Header */
+
+.jumbotron {
+  padding: .5rem;
+  margin-bottom: 1rem;
+}
+
+.jumbotron h2 {
+  margin-bottom: .5rem;
+}
+
+/* Title */
+
+.h1, .h2, .h3, .h4, .h5, .h6, h1, h2, h3, h4, h5, h6 {
+    margin-bottom: 1rem;
+}
+
+/* Footer */
+/* Sticky footer styles - https://getbootstrap.com/docs/4.0/examples/sticky-footer-navbar/ */
+
 html {
   position: relative;
   min-height: 100%;


### PR DESCRIPTION
- Various cosmetic website tweaks (e.g. margins of header and titles)
- Fixed invalid FR "References" page link
  - Had to rename both to "references-en.html" and "references-fr.html". @gcharest should we create a redirection in "references.html" or it's not worth it?
