### PR TITLE
re-added risk in the mission statement

### DIFF
--- a/_pages/en/mandate.md
+++ b/_pages/en/mandate.md
@@ -18,7 +18,7 @@ Continuous improvement transformation and GC wide "Government as a service" base
 
 ## Mission (team's reason for existence)
 
-Enable the strategic value of IT within ESDC by reducing its risks to increase business agility.
+Enable the strategic value of IT within ESDC by reducing its risks and increase business agility.
 
 ## Mandate (team's authority within IITB)
 

--- a/_pages/en/mandate.md
+++ b/_pages/en/mandate.md
@@ -18,7 +18,7 @@ Continuous improvement transformation and GC wide "Government as a service" base
 
 ## Mission (team's reason for existence)
 
-Enable the strategic value of IT within ESDC to increase business agility.
+Enable the strategic value of IT within ESDC by reducing its risks to increase business agility.
 
 ## Mandate (team's authority within IITB)
 
@@ -50,9 +50,9 @@ If IT fails, business fails and vice versa.
 The use of technology is no longer "an IT problem" as it has real repercussions to citizens.
 IT can no longer be seen as a company within another company (or an outside supplier), it has shared accountability with the organization's mandate and is a strategic asset.
 
-Current IT processes and methods take a long time to deliver or change applications, devices and support.
+Current IT processes and governance methods are risky and costly, which translates into long time to deliver or change applications, devices and support.
 Recovering from incidents is hard and errors resulting from changes are frequent.
-We must reduce these risks and continuously improve in all areas related to IT.
+We must reduce risks associated with IT and continuously improve in all of its areas.
 
 That is **Digital Transformation**.
 

--- a/_pages/en/mandate.md
+++ b/_pages/en/mandate.md
@@ -18,7 +18,7 @@ Continuous improvement transformation and GC wide "Government as a service" base
 
 ## Mission (team's reason for existence)
 
-Enable the strategic value of IT within ESDC by reducing its risks and increase business agility.
+Enable the strategic value of IT within ESDC by reducing its risks and increasing business agility.
 
 ## Mandate (team's authority within IITB)
 


### PR DESCRIPTION
Our mission statement must have de-risking the use of IT
It's the whole "transformation" in the digital transformation. As mentioned in War & Peace & IT

quote from page xxvi

> Now is the time to start transforming, because it's both low risk and urgent. You might be surprised that I say it's low risk, but I insist. Enterprises may feel like they should move slowly and cautiously, stepping onto the digital path only after they've checked the traffic coming from all directions.

> But the very point of digital transformation is to *reduce* risk. 

> Digital enterprises set risk-mitigating guardrails in place, then use their speed as a way to quickly adjust course when new risks appear.