### PR TITLE
Sections update

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ description:
   en: Working in the open! Our work in progress, list of reference material and presentations.
   fr: Travailler ouvertement! Nos travaux en cours, liste de documents de références et présentations.
 sectionsList:
-  en: ["About us", "Work In Progress", "IT Picture", "Trends", "Under Review", "Archives"]
-  fr: ["À propos de nous", "Travaux en cours", "Image de la TI", "Tendances", "En révision", "Archives"]
+  en: ["About us","IT Picture", "Trends", "Under Review", "Work In Progress", "Archives"]
+  fr: ["À propos de nous", "Image de la TI", "Tendances", "En révision", "Travaux en cours", "Archives"]
 docsTitle:
   en: Our Documents
   fr: Nos documents

--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ description:
   en: Working in the open! Our work in progress, list of reference material and presentations.
   fr: Travailler ouvertement! Nos travaux en cours, liste de documents de références et présentations.
 sectionsList:
-  en: ["About us","IT Picture", "Trends", "Under Review", "Work In Progress", "Archives"]
-  fr: ["À propos de nous", "Image de la TI", "Tendances", "En révision", "Travaux en cours", "Archives"]
+  en: ["About us","Ready For Use", "Trends", "Under Review", "Work In Progress", "Archives"]
+  fr: ["À propos de nous", "Prêt à utiliser", "Tendances", "En révision", "Travaux en cours", "Archives"]
 docsTitle:
   en: Our Documents
   fr: Nos documents

--- a/_pages/en/building-enabling-directorate.md
+++ b/_pages/en/building-enabling-directorate.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Building Nested Enabling Teams
-ref: mandate
+ref: enabling-directorate
 lang: en
 status: posted
 sections: Work In Progress

--- a/_pages/en/capabilities.md
+++ b/_pages/en/capabilities.md
@@ -4,7 +4,7 @@ title: High Performing IT Capabilities
 ref: it-capabilities
 lang: en
 status: posted
-sections: Work In Progress
+sections: Archives
 permalink: /high-performing-it-capabilities.html
 ---
 

--- a/_pages/en/esdc-it-strategy.md
+++ b/_pages/en/esdc-it-strategy.md
@@ -4,7 +4,7 @@ title: ESDC IT Strategy
 ref: esdc-it-strategy
 lang: en
 status: posted
-sections: "About us"
+sections: IT Picture
 permalink: /esdc-it-strategy.html
 ---
 

--- a/_pages/en/esdc-it-strategy.md
+++ b/_pages/en/esdc-it-strategy.md
@@ -4,7 +4,7 @@ title: ESDC IT Strategy
 ref: esdc-it-strategy
 lang: en
 status: posted
-sections: IT Picture
+sections: Ready For Use
 permalink: /esdc-it-strategy.html
 ---
 

--- a/_pages/en/it-picture-long-term.md
+++ b/_pages/en/it-picture-long-term.md
@@ -4,14 +4,15 @@ title: IT Picture - Long Term
 ref: it-picture-long-term
 lang: en
 status: posted
-sections: Work In Progress
+sections: IT Picture
 permalink: /it-picture-long-term.html
 ---
 
 ## Long Term IT Picture - 2030
 
-- [GC Wide](#gc-wide)
-- [IT within ESDC](#it-within-esdc)
+- [Long Term IT Picture - 2030](#long-term-it-picture---2030)
+  - [GC Wide](#gc-wide)
+  - [IT within ESDC](#it-within-esdc)
 
 ### GC Wide
 

--- a/_pages/en/it-picture-long-term.md
+++ b/_pages/en/it-picture-long-term.md
@@ -4,7 +4,7 @@ title: IT Picture - Long Term
 ref: it-picture-long-term
 lang: en
 status: posted
-sections: IT Picture
+sections: Ready For Use
 permalink: /it-picture-long-term.html
 ---
 

--- a/_pages/en/it-picture-medium-term.md
+++ b/_pages/en/it-picture-medium-term.md
@@ -4,20 +4,21 @@ title: IT Picture - Medium Term
 ref: it-picture-medium-term
 lang: en
 status: posted
-sections: Work In Progress
+sections: IT Picture
 permalink: /it-picture-medium-term.html
 ---
 
 ## Medium Term IT Picture - 2025
 
-- [GC Wide](#gc-wide)
-- [IT within ESDC](#it-within-esdc)
-- [Cultural](#cultural)
-  - [Additional Reading](#additional-reading)
-- [Process](#process)
-- [Technical](#technical)
-- [Measurement](#measurement)
-- [Additional Reading](#additional-reading-1)
+- [Medium Term IT Picture - 2025](#medium-term-it-picture---2025)
+  - [GC Wide](#gc-wide)
+  - [IT within ESDC](#it-within-esdc)
+    - [Cultural](#cultural)
+      - [Additional Reading](#additional-reading)
+    - [Process](#process)
+    - [Technical](#technical)
+    - [Measurement](#measurement)
+  - [Additional Reading](#additional-reading-1)
 
 ### GC Wide
 

--- a/_pages/en/it-picture-medium-term.md
+++ b/_pages/en/it-picture-medium-term.md
@@ -4,7 +4,7 @@ title: IT Picture - Medium Term
 ref: it-picture-medium-term
 lang: en
 status: posted
-sections: IT Picture
+sections: Ready For Use
 permalink: /it-picture-medium-term.html
 ---
 

--- a/_pages/en/speaking_notes.md
+++ b/_pages/en/speaking_notes.md
@@ -4,7 +4,7 @@ title: IT Strategy feedback
 ref: feedback-speaking-notes
 lang: en
 status: archived
-sections: About us
+sections: Archives
 permalink: /feedback-speaking-notes.html
 ---
 

--- a/_pages/en/strategies-actions.md
+++ b/_pages/en/strategies-actions.md
@@ -4,7 +4,7 @@ title: IT Strategies and Actions
 ref: strategies
 lang: en
 status: posted
-sections: IT Picture
+sections: Ready For Use
 permalink: /strategies-actions.html
 ---
 

--- a/_pages/en/strategies-actions.md
+++ b/_pages/en/strategies-actions.md
@@ -4,7 +4,7 @@ title: IT Strategies and Actions
 ref: strategies
 lang: en
 status: posted
-sections: Work In Progress
+sections: IT Picture
 permalink: /strategies-actions.html
 ---
 

--- a/_pages/en/strategy-summary.md
+++ b/_pages/en/strategy-summary.md
@@ -4,7 +4,7 @@ title: Strategy Map
 ref: summary
 lang: en
 status: posted
-sections: About us
+sections: IT Picture
 permalink: /strategy-summary.html
 ---
 

--- a/_pages/en/strategy-summary.md
+++ b/_pages/en/strategy-summary.md
@@ -4,7 +4,7 @@ title: Strategy Map
 ref: summary
 lang: en
 status: posted
-sections: IT Picture
+sections: Ready For Use
 permalink: /strategy-summary.html
 ---
 

--- a/_pages/fr/dgiit-ipc.md
+++ b/_pages/fr/dgiit-ipc.md
@@ -4,7 +4,7 @@ title: Indicateurs de Rendement Clés
 ref: kpi
 lang: fr
 status: posted
-sections: Travaux en cours
+sections: Archives
 permalink: /dgiit-ipc.html
 ---
 

--- a/_pages/fr/retroaction-strategie-it.md
+++ b/_pages/fr/retroaction-strategie-it.md
@@ -4,7 +4,7 @@ title: Rétroaction sur les stratégie de TI
 ref: feedback-speaking-notes
 lang: fr
 status: archived
-sections: À propos de nous
+sections: Archives
 permalink: /notes-allocution-retroaction.html
 ---
 

--- a/_pages/fr/sommaire-strategie.md
+++ b/_pages/fr/sommaire-strategie.md
@@ -4,7 +4,7 @@ title: Carte de stratégies
 ref: summary
 lang: fr
 status: posted
-sections: Image de la TI
+sections: Prêt à utiliser
 permalink: /sommaire-strategie.html
 ---
 

--- a/_pages/fr/sommaire-strategie.md
+++ b/_pages/fr/sommaire-strategie.md
@@ -4,7 +4,7 @@ title: Carte de stratégies
 ref: summary
 lang: fr
 status: posted
-sections: À propos de nous
+sections: Image de la TI
 permalink: /sommaire-strategie.html
 ---
 


### PR DESCRIPTION
J'ai changé les sections pour mettre le contenu "à la bonne place" L'idée est d'utiliser les bonnes sections pour avoir les "statut" des documents sur le site plus clairs.

Tout ce qui est `Travail en cours` devrait essentiellement être un brouillon, l'Image de la TI est les documents qui nous avaient été demandés, etc.

On pourrait créer d'autres sections au besoin pour ce qui est d'autres sortes de documents matures.

Règle le problème #300 