### PR TITLE
Versioning

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -18,7 +18,7 @@ description:
   en: Working in the open! Our work in progress, list of reference material and presentations.
   fr: Travailler ouvertement! Nos travaux en cours, liste de documents de références et présentations.
 sectionsList:
-  en: ["About us","Ready For Use", "Trends", "Under Review", "Work In Progress", "Archives"]
+  en: ["About us", "Ready For Use", "Trends", "Under Review", "Work In Progress", "Archives"]
   fr: ["À propos de nous", "Prêt à utiliser", "Tendances", "En révision", "Travaux en cours", "Archives"]
 docsTitle:
   en: Our Documents
@@ -53,6 +53,9 @@ pagesOther:
 subtitle:
   en: Enable the strategic value of IT within ESDC by reducing its risks to accelerate business flexibility.
   fr: Favoriser la valeur stratégique des TI au sein de EDSC en réduisant leurs risques afin d'accélérer la flexibilité de l'entreprise.
+docVersionNumber:
+  en: Document Version
+  fr: Version du document
 thisPageHasMoved:
   en: "This page has been modified and can now be found at the following link:"
   fr: "Cette page a été modifiée et peut maintenant être trouvée au lien suivant:"

--- a/_includes/versioning.md
+++ b/_includes/versioning.md
@@ -1,0 +1,8 @@
+{% if page.sections == "Ready For Use" or "Prêt à utiliser" %}
+    {% if page.date %}
+        {{ site.lastModified[page.lang] }}: {{ page.date | date: "%Y-%m-%d"}}
+    {%endif%}
+    {% if page.version %}
+        {{ site.docVersionNumber[page.lang] }}: {{ page.version }}
+    {% endif %}
+{% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,6 +8,7 @@
     {% include header.html %}
 
     <main class="container">
+      {% include versioning.md %}
       {{ content }}
     </main>
     


### PR DESCRIPTION
Added version and date on documents.

Only displays if the document is in section "Ready to use" and either of the following tags are added in the front matter:
- `date:`
- `version:`

Following PR #407 comments from @remyb2canada 