### PR TITLE
Move notice above footer

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -51,5 +51,3 @@
     <h2>{{ site.subtitle[page.lang] }}</h2>
   </div>
 </div>
-
-{% include notice.html %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -13,7 +13,8 @@
       {% endif %}
       {{ content }}
     </main>
-    
+
+    {% include notice.html %}    
     {% include footer.html %}
 
   </body>


### PR DESCRIPTION
This moves the notice from the top of the page to the bottom.  Makes for less scrolling when you get to a page.