### PR TITLE
Remove planning information from Q1 strategy page

### DIFF
--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -14,9 +14,8 @@ The following strategies and actions apply for the 1st quarter of the 2020-2021 
 Strategies will be reviewed and updated quarterly based on current progress and following the Strategy Map (layering on the strategies).
 
 - [Goals](#goals)
-- [IITB teams must](#iitb-teams-must)
-- [IITB must](#iitb-must)
-- [IT Strategy Will](#it-strategy-will)
+- [Actions](#actions)
+- [Guidance](#guidance)
 
 ### Goals
 
@@ -34,7 +33,9 @@ Strategies will be reviewed and updated quarterly based on current progress and 
 - [Mandatory Procedures on APIs](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32604)
 - [Acceptable Network and Device Use](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32605)
 
-### IITB teams must
+### Actions
+
+All IITB teams must:
 
 #### Use 20% of time to learn, automate and improve
 
@@ -44,7 +45,7 @@ Strategies will be reviewed and updated quarterly based on current progress and 
   - **Time to restore following incidents and errors**
   - **Change fail rate**
 
-##### Guidance
+### Guidance
 
 - Read, take courses, attend events and conferences
 - Stay up to date on trends and technologies
@@ -57,42 +58,3 @@ Strategies will be reviewed and updated quarterly based on current progress and 
 - Employee to employee education (Getting on "teaching mode" and educating your team on specific question).
 - Show and tell across the teams (Getting to know which team is working on what, getting feedback).
 - Organizing IITB tech talks
-
-### IITB must
-
-#### Before Q1
-
-- Make quarterly strategies a requirement in performance agreements of directors, managers and team leads
-- Create cloud and desktop sandboxes (labs) for experimentation
-- [Grant access to more Web tools for IITB employees](web-services-access.html)
-- Add all approved desktop software, including commercial and OSS, to Application Catalogue
-
-### IT Strategy Will
-
-#### Before Q1
-
-- Draft requirements for 2020-04 updates to PMAs (must follow quarterly strategies)
-- Create CATS code for continuous improvement
-- [Grant access to more Web tools for IITB employees](web-services-access.html)
-
-#### During Q1
-
-- [Coordinate communications of strategies](#coordinate-communications-of-strategies)
-- [Organize a Hackathon for IITB and ESDC](#organize-a-hackathon-for-iitb-and-esdc)
-- Survey about Q1 strategies
-- Prepare Q2 strategies
-
-#### Coordinate communications of strategies
-
-- IT Strategy blogs, newsletters, tweets, ..
-- Regular communications about:
-  - Updated direction around learning and upcoming learning opportunities
-  - Failures and lessons learned - link back to learning opportunities
-  - Use of SaaS on ESDC network for unclassified information
-  - Progress reports around continuous improvements and automation
-
-#### Organize a Hackathon for IITB and ESDC
-
-- Host first hackathon (2020-04)
-  - Promote learning, automation and improvement
-  - Digital, agile and cloud

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -26,7 +26,7 @@ All IITB teams must:
 
 | Action | Guidance |
 |--------|----------|
-| **Learn** | - Read, take courses, attend events and conferences<br /> - Stay up to date on trends and technologies</br> - Encourage assignments with CDS-ESDC team or CSPS<br /> - Share knowledge with colleagues (IITB showcase, Dev CoP, GCconnex, GCcollab, ..)<br /> - Peer coaching/mentoring<br /> - Show and tell across the teams |
+| **Learn** | - Read, take courses, attend events and conferences<br /> - Stay up to date on trends and technologies</br> - Encourage assignments with CDS-ESDC team or CSPS<br /> - Share knowledge with colleagues (IITB showcase, Dev CoP, GCconnex, GCcollab, ..)<br /> - Peer coaching/mentorship <br /> - Show and tell across the teams |
 | **Automate** | - Automate where possible |
 | **Improve processes** | - Review existing processes and governance structure |
 | **Show progress** | - Gather metrics for things your team works on |

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -22,12 +22,16 @@ All IITB teams must:
 
 #### Use 20% of time to learn, automate and improve
 
+<!-- markdownlint-disable MD033 -->
+
 | Action | Guidance |
 |--------|----------|
 | **Learn** | - Read, take courses, attend events and conferences<br /> - Stay up to date on trends and technologies</br> - Encourage assignments with CDS-ESDC team or CSPS<br /> - Share knowledge with colleagues (IITB showcase, Dev CoP, GCconnex, GCcollab, ..)<br /> - Peer coaching/mentoring<br /> - Show and tell across the teams |
 | **Automate** | - Automate where possible |
 | **Improve processes** | - Review existing processes and governance structure |
 | **Show progress** | - Gather metrics for things your team works on |
+
+<!-- markdownlint-enable MD033 -->
 
 **For all these activities, use CATS codes for continuous improvement.**
 

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -10,12 +10,11 @@ permalink: /strategy-learning-automating-improving.html
 
 ## Strategy - Continuous Learning, Automation and Improvement
 
-The following strategies and actions apply for the 1st quarter of the 2020-2021 fiscal year.
-Strategies will be reviewed and updated quarterly based on current progress and following the Strategy Map (layering on the strategies).
+The following actions apply for the 1st quarter of the 2020-2021 fiscal year.
+Strategies and actions will be reviewed and updated quarterly based on current progress and following the Strategy Map (layering on the strategies).
 
 - [Actions](#actions)
 - [Goals](#goals)
-- [Guidance](#guidance)
 
 ### Actions
 
@@ -23,9 +22,14 @@ All IITB teams must:
 
 #### Use 20% of time to learn, automate and improve
 
-- **Use CATS codes for continuous improvement**
-- **Gather metrics for things your teams work on**
-- **Show progress**
+| Action | Guidance |
+|--------|----------|
+| **Learn** | - Read, take courses, attend events and conferences<br /> - Stay up to date on trends and technologies</br> - Encourage assignments with CDS-ESDC team or CSPS<br /> - Share knowledge with colleagues (IITB showcase, Dev CoP, GCconnex, GCcollab, ..)<br /> - Peer coaching/mentoring<br /> - Show and tell across the teams |
+| **Automate** | - Automate where possible |
+| **Improve processes** | - Review existing processes and governance structure |
+| **Show progress** | - Gather metrics for things your team works on | 
+
+**For all these activities, use CATS codes for continuous improvement.**
 
 ### Goals
 
@@ -42,17 +46,3 @@ All IITB teams must:
   - [Mandatory Procedures for EA Assessment](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32602)
   - [Mandatory Procedures on APIs](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32604)
   - [Acceptable Network and Device Use](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32605)
-
-### Guidance
-
-- Read, take courses, attend events and conferences
-- Stay up to date on trends and technologies
-- Encourage assignments with CDS-ESDC team or CSPS
-- Share knowledge with colleagues
-  - IITB showcase, Dev CoP, GCconnex, GCcollab, ..
-- Review existing processes and governance structure
-- Automate where possible
-- Peer coaching (Informal training that extends beyond onboarding. Managers should spend one-on-one time with workers, getting information from them that will help in crafting the learning path that is individualized to their needs.)
-- Employee to employee education (Getting on "teaching mode" and educating your team on specific question).
-- Show and tell across the teams (Getting to know which team is working on what, getting feedback).
-- Organizing IITB tech talks

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -26,7 +26,7 @@ All IITB teams must:
 
 | Action | Guidance |
 |--------|----------|
-| **Learn** | - Read, take courses, attend events and conferences<br /> - Stay up to date on trends and technologies</br> - Encourage assignments with CDS-ESDC team or CSPS<br /> - Share knowledge with colleagues (IITB showcase, Dev CoP, GCconnex, GCcollab, ..)<br /> - Peer coaching/mentorship <br /> - Show and tell across the teams |
+| **Learn** | - Read, take courses, attend events and conferences<br /> - Stay up to date on trends and technologies</br> - Encourage assignments with CDS-ESDC team or CSPS<br /> - Share knowledge with colleagues (IITB showcase, Dev CoP, GCconnex, GCcollab, ..)<br /> - Peer coaching <br /> - Show and tell across the teams |
 | **Automate** | - Automate where possible |
 | **Improve processes** | - Review existing processes and governance structure |
 | **Show progress** | - Gather metrics for things your team works on |

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -13,9 +13,19 @@ permalink: /strategy-learning-automating-improving.html
 The following strategies and actions apply for the 1st quarter of the 2020-2021 fiscal year.
 Strategies will be reviewed and updated quarterly based on current progress and following the Strategy Map (layering on the strategies).
 
-- [Goals](#goals)
 - [Actions](#actions)
+- [Goals](#goals)
 - [Guidance](#guidance)
+
+### Actions
+
+All IITB teams must:
+
+#### Use 20% of time to learn, automate and improve
+
+- **Use CATS codes for continuous improvement**
+- **Gather metrics for things your teams work on**
+- **Show progress**
 
 ### Goals
 
@@ -32,16 +42,6 @@ Strategies will be reviewed and updated quarterly based on current progress and 
   - [Mandatory Procedures for EA Assessment](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32602)
   - [Mandatory Procedures on APIs](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32604)
   - [Acceptable Network and Device Use](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32605)
-
-### Actions
-
-All IITB teams must:
-
-#### Use 20% of time to learn, automate and improve
-
-- **Use CATS codes for continuous improvement**
-- **Gather metrics for things your teams work on**
-- **Show progress**
 
 ### Guidance
 

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Strategy - Continuous Learning, Automation and Improvement
-ref: strategy-q1
+ref: strategy-q1-2020
 lang: en
 status: posted
 sections: Ready For Use

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -41,9 +41,7 @@ All IITB teams must:
 
 - **Use CATS codes for continuous improvement**
 - **Gather metrics for things your teams work on**
-  - **Lead time for change or delivery of services/devices**
-  - **Time to restore following incidents and errors**
-  - **Change fail rate**
+- **Show progress**
 
 ### Guidance
 

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Strategy - Continuous Learning, Automation and Improvement
-ref: strategies
+ref: strategy-q1
 lang: en
 status: posted
 sections: Ready For Use
@@ -27,7 +27,7 @@ All IITB teams must:
 | **Learn** | - Read, take courses, attend events and conferences<br /> - Stay up to date on trends and technologies</br> - Encourage assignments with CDS-ESDC team or CSPS<br /> - Share knowledge with colleagues (IITB showcase, Dev CoP, GCconnex, GCcollab, ..)<br /> - Peer coaching/mentoring<br /> - Show and tell across the teams |
 | **Automate** | - Automate where possible |
 | **Improve processes** | - Review existing processes and governance structure |
-| **Show progress** | - Gather metrics for things your team works on | 
+| **Show progress** | - Gather metrics for things your team works on |
 
 **For all these activities, use CATS codes for continuous improvement.**
 

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -29,9 +29,9 @@ Strategies will be reviewed and updated quarterly based on current progress and 
 - [Digital Standards](https://www.canada.ca/en/government/system/digital-government/government-canada-digital-standards.html)
 - [Digital Operations Strategic Plan: 2018-2022](https://www.canada.ca/en/government/system/digital-government/digital-operations-strategic-plan-2018-2022.html)
 - [Policy](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32603) and [Directive on Service and Digital](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32601)
-- [Mandatory Procedures for EA Assessment](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32602)
-- [Mandatory Procedures on APIs](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32604)
-- [Acceptable Network and Device Use](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32605)
+  - [Mandatory Procedures for EA Assessment](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32602)
+  - [Mandatory Procedures on APIs](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32604)
+  - [Acceptable Network and Device Use](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32605)
 
 ### Actions
 


### PR DESCRIPTION
Keep it simple.  2 sections: Actions and Goals.

Guidance for each action in a table.