### PR TITLE
Update Q1 strategy actions guidance

### DIFF
--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -43,7 +43,8 @@ All IITB teams must:
 
 ##### Improve
 
-- Define definition of improvement and objectives for your team
+- Understand teams performance levels and set realistic goals
+- Identify gaps in your daily work performance and establish improvement priorities
 - Gather metrics (ex.: start and end date) for things your team works on
 - Show improvement based on metrics
 - Review existing processes and governance structure

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Strategy - Continuous Learning, Automation and Improvement
+title: Strategy - Continuous Learning and Improvement
 ref: strategy-q1-2020
 lang: en
 status: posted
@@ -8,7 +8,7 @@ sections: Ready For Use
 permalink: /strategy-learning-automating-improving.html
 ---
 
-## Strategy - Continuous Learning, Automation and Improvement
+## Strategy - Continuous Learning and Improvement
 
 The following actions apply for the 1st quarter of the 2020-2021 fiscal year.
 Strategies and actions will be reviewed and updated quarterly based on current progress and following the Strategy Map (layering on the strategies).
@@ -20,15 +20,14 @@ Strategies and actions will be reviewed and updated quarterly based on current p
 
 All IITB teams must:
 
-#### Use 20% of time to learn, automate and improve
+#### Use 20% of time to learn and improve
 
 <!-- markdownlint-disable MD033 -->
 
 | Action | Guidance |
 |--------|----------|
-| **Learn** | - Read, take courses, attend events and conferences<br /> - Stay up to date on trends and technologies<br /> - Encourage assignments with CDS-ESDC team or CSPS<br /> - Share knowledge with colleagues (IITB showcase, Dev CoP, GCconnex, GCcollab, ..)<br /> - Peer coaching <br /> - Show and tell across the teams |
-| **Automate** | - Automate where possible |
-| **Improve processes** | - Review existing processes and governance structure |
+| **Learn** | - Read, take courses, attend events and conferences<br /> - Stay up to date on trends and technologies<br /> - Encourage assignments with CDS-ESDC team or CSPS<br /> - Share knowledge with colleagues (IITB showcase, Dev CoP, GCconnex, GCcollab, ..)<br /> - Peer coaching<br /> - Show and tell across the teams |
+| **Improve processes** | - Review existing processes and governance structure<br /> - Automate where possible |
 | **Show progress** | - Gather metrics for things your team works on |
 
 <!-- markdownlint-enable MD033 -->
@@ -37,7 +36,7 @@ All IITB teams must:
 
 ### Goals
 
-- Continuously learn, automate and improve
+- Continuously learn and improve
 - Reduce lead time for changes and delivery of services/devices
 - Recover faster incidents and errors
 - Reduce frequency of incidents and errors

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -27,18 +27,18 @@ All IITB teams must:
 ##### Learn
 
 - Stay up to date on trends and technologies inside and outside the GC
-- Learn new tools, technologies or methodologies (Containers, Cloud, Agile, DevOps, ..)
+- Learn new tools, technologies or methodologies (Containers, Cloud, Agile, DevOps, ..), locally or in public cloud sandboxes
 - Read books, articles or documentation
-- Take courses online or in person
+- Take courses online (including MOOCs - massive open online courses) or in person
 - Attend events or conferences
 - Go on assignments/micro missions across ESDC functional/business unit as well as outside ESDC
 - Attend IITB showcase, Dev CoP, dojos or other learning opportunities within IITB and ESDC
 - Participate in "Innovation" at ESDC and Innovation Lab design sessions
+- Explore data science opportunities with ESDC Chief Data Office (CDO)
 - Setup a recurring time to share knowledge with colleagues within your team (small, 5-10 people)
 - Find/become a mentor/coach
-- Join groups and participate in discussions on GCconnex and GCcollab
+- Join groups and participate in discussions on GCconnex/GCcollab, as well as external communities
 - Take part in Service Canada staff training
-- Complete mandatory training
 - Register for training/events offered by ESDC and CSPS
 
 ##### Improve
@@ -48,7 +48,7 @@ All IITB teams must:
 - Show improvement based on metrics
 - Review existing processes and governance structure
 - Identify issues and raise them to your manager or as Grassroots initiatives or Proof of concepts
-- Automate repetitive manual tasks where possible
+- Automate repetitive manual tasks where possible, at the team and individual level
 
 ### Goals
 

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -63,6 +63,6 @@ All IITB teams must:
 - [Digital Standards](https://www.canada.ca/en/government/system/digital-government/government-canada-digital-standards.html)
 - [Digital Operations Strategic Plan: 2018-2022](https://www.canada.ca/en/government/system/digital-government/digital-operations-strategic-plan-2018-2022.html)
 - [Policy](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32603) and [Directive on Service and Digital](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32601)
-  - [Mandatory Procedures for EA Assessment](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32602)
-  - [Mandatory Procedures on APIs](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32604)
+  - [Mandatory Procedures for Enterprise Architecture (EA) Assessment](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32602)
+  - [Mandatory Procedures on Application Programming Interfaces (API)](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32604)
   - [Acceptable Network and Device Use](https://www.tbs-sct.gc.ca/pol/doc-eng.aspx?id=32605)

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -22,12 +22,12 @@ All IITB teams must:
 
 #### Use 20% of time to learn and improve
 
-**For all these activities, use CATS codes for continuous improvement.**
+**For all the following and other related activities, use CATS codes for continuous improvement (######).**
 
 ##### Learn
 
 - Stay up to date on trends and technologies inside and outside the GC
-- Learn new tools, technologies or methodologies (Containers, Cloud, Agile, DevOps, ..), locally or in public cloud sandboxes
+- Learn new tools, technologies or methodologies (Containers, Cloud, Agile, ..), locally or in public sandboxes
 - Read books, articles or documentation
 - Take courses online (including MOOCs - massive open online courses) or in person
 - Attend events or conferences
@@ -46,7 +46,7 @@ All IITB teams must:
 - Understand teams performance levels and set realistic goals
 - Identify gaps in your daily work performance and establish improvement priorities
 - Gather metrics (ex.: start and end date) for things your team works on
-- Show improvement based on metrics
+- Show improvement based on metrics, the [Goals](#goals) and your team's mandate
 - Review existing processes and governance structure
 - Identify issues and raise them to your manager or as Grassroots initiatives or Proof of concepts
 - Automate repetitive manual tasks where possible, at the team and individual level

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -22,16 +22,33 @@ All IITB teams must:
 
 #### Use 20% of time to learn and improve
 
-<!-- markdownlint-disable MD033 -->
-
-| Action | Guidance |
-|--------|----------|
-| **Learn** | - Stay up to date on trends and technologies<br > - Learn new tools, technologies or methodologies (Containers, Cloud, Agile, DevOps, ..)<br > - Read books, articles or documentation<br > - Take courses online or in person<br > - Attend events or conferences<br > - Go on assignments/micro missions across ESDC functional/business unit as well as outside ESDC<br > - Attend IITB showcase, Dev CoP, dojos or other learning opportunities within IITB and ESDC<br > - Participate in "Innovation" at ESDC and Innovation Lab design sessions<br > - Setup a recurring time to share knowledge with colleagues within your team (small, 5-10 people)<br > - Find/become a mentor/coach<br > - Join groups and participate in discussions on GCconnex and GCcollab<br > - Take part in Service Canada staff training<br > - Complete mandatory training<br > - Register for training/events offered by ESDC and CSPS |
-| **Improve** | - Define definition of improvement and objectives for your team<br > - Gather metrics (ex.: start and end date) for things your team works on<br > - Show improvement based on metrics<br > - Review existing processes and governance structure<br > - Identify issues and raise them to your manager or as Grassroots initiatives or Proof of concepts<br > - Automate repetitive manual tasks where possible |
-
-<!-- markdownlint-enable MD033 -->
-
 **For all these activities, use CATS codes for continuous improvement.**
+
+##### Learn
+
+- Stay up to date on trends and technologies inside and outside the GC
+- Learn new tools, technologies or methodologies (Containers, Cloud, Agile, DevOps, ..)
+- Read books, articles or documentation
+- Take courses online or in person
+- Attend events or conferences
+- Go on assignments/micro missions across ESDC functional/business unit as well as outside ESDC
+- Attend IITB showcase, Dev CoP, dojos or other learning opportunities within IITB and ESDC
+- Participate in "Innovation" at ESDC and Innovation Lab design sessions
+- Setup a recurring time to share knowledge with colleagues within your team (small, 5-10 people)
+- Find/become a mentor/coach
+- Join groups and participate in discussions on GCconnex and GCcollab
+- Take part in Service Canada staff training
+- Complete mandatory training
+- Register for training/events offered by ESDC and CSPS
+
+##### Improve
+
+- Define definition of improvement and objectives for your team
+- Gather metrics (ex.: start and end date) for things your team works on
+- Show improvement based on metrics
+- Review existing processes and governance structure
+- Identify issues and raise them to your manager or as Grassroots initiatives or Proof of concepts
+- Automate repetitive manual tasks where possible
 
 ### Goals
 

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -26,9 +26,8 @@ All IITB teams must:
 
 | Action | Guidance |
 |--------|----------|
-| **Learn** | - Read, take courses, attend events and conferences<br /> - Stay up to date on trends and technologies<br /> - Encourage assignments with CDS-ESDC team or CSPS<br /> - Share knowledge with colleagues (IITB showcase, Dev CoP, GCconnex, GCcollab, ..)<br /> - Peer coaching<br /> - Show and tell across the teams |
-| **Improve processes** | - Review existing processes and governance structure<br /> - Automate where possible |
-| **Show progress** | - Gather metrics for things your team works on |
+| **Learn** | - Stay up to date on trends and technologies<br > - Learn new tools, technologies or methodologies (Containers, Cloud, Agile, DevOps, ..)<br > - Read books, articles or documentation<br > - Take courses online or in person<br > - Attend events or conferences<br > - Go on assignments/micro missions across ESDC functional/business unit as well as outside ESDC<br > - Attend IITB showcase, Dev CoP, dojos or other learning opportunities within IITB and ESDC<br > - Participate in "Innovation" at ESDC and Innovation Lab design sessions<br > - Setup a recurring time to share knowledge with colleagues within your team (small, 5-10 people)<br > - Find/become a mentor/coach<br > - Join groups and participate in discussions on GCconnex and GCcollab<br > - Take part in Service Canada staff training<br > - Complete mandatory training<br > - Register for training/events offered by ESDC and CSPS |
+| **Improve** | - Define definition of improvement and objectives for your team<br > - Gather metrics (ex.: start and end date) for things your team works on<br > - Show improvement based on metrics<br > - Review existing processes and governance structure<br > - Identify issues and raise them to your manager or as Grassroots initiatives or Proof of concepts<br > - Automate repetitive manual tasks where possible |
 
 <!-- markdownlint-enable MD033 -->
 

--- a/cspell.json
+++ b/cspell.json
@@ -281,7 +281,8 @@
     "onenote",
     "Kylie",
     "PGPP",
-    "préapprouvé"
+    "préapprouvé",
+    "Moocs"
   ],
   "flagWords": [],
   "import": ["./node_modules/cspell-dict-fr-fr/cspell-ext.json"],


### PR DESCRIPTION
As discussed I removed Automation from the action for the Q1 strategy.

I also updated the list of guidance based on discussion.  I changed it back to a list from a table to make it easier to comment and edit.  We can always go back to a table for better presentation later.

We should rename the file name and permalink, but that would break links we shared already

