### PR TITLE
Fix easy accessibility errors found with WAVE

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header>
   <nav class="navbar navbar-expand-md navbar-light fixed-top bg-light">
     <div class="container-fluid">
-    <a class="navbar-brand" href="{% if page.lang == 'en' %}{{ site.baseurl }}/{{ site.index.en }}{% else %}{{ site.baseurl }}/{{ site.index.fr }}{% endif %}"><i class="fas fa-home"></i></a></li></a>
+    <a aria-label="Home" class="navbar-brand" href="{% if page.lang == 'en' %}{{ site.baseurl }}/{{ site.index.en }}{% else %}{{ site.baseurl }}/{{ site.index.fr }}{% endif %}"><i class="fas fa-home"></i></a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#Menu1" aria-controls="Menu1" aria-expanded="false" aria-label="Toggle navigation">
       <span class="custom-toggler-icon"><i class="fas fa-bars"></i></span>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,7 +1,7 @@
 <header>
   <nav class="navbar navbar-expand-md navbar-light fixed-top bg-light">
     <div class="container-fluid">
-    <a aria-label="Home" class="navbar-brand" href="{% if page.lang == 'en' %}{{ site.baseurl }}/{{ site.index.en }}{% else %}{{ site.baseurl }}/{{ site.index.fr }}{% endif %}"><i class="fas fa-home"></i></a>
+    <a aria-label="Home" class="navbar-brand" href="{% if page.lang == 'en' %}{{ site.baseurl }}/{{ site.index.en }}{% else %}{{ site.baseurl }}/{{ site.index.fr }}{% endif %}"><span class="fas fa-home" aria-hidden="true"></span></a>
 
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#Menu1" aria-controls="Menu1" aria-expanded="false" aria-label="Toggle navigation">
       <span class="custom-toggler-icon"><i class="fas fa-bars"></i></span>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -172,9 +172,10 @@ li .nav-link {
   color: #545454 !important;
 }
 
-p a {
+main a {
   color: #0054B3 !important;
 }
+
 .custom-toggler-icon {
   color: white;
   font-size: 1.6rem;


### PR DESCRIPTION
Tested Website using https://addons.mozilla.org/en-CA/firefox/addon/wave-accessibility-tool/

Fix error with the home logo not having a label. And removed extra HTML `</li></a>` from the same line

Applied the style for links in paragraph to all links in main content.  This does not affect the header or footer.  But the notice is part of main and the PR change the link color from the default alert color to blue.