### PR TITLE
resolved code highlighting color contrast

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -457,3 +457,14 @@ Extra (xl) large devices (large desktops, 1200px and up)
 @media (min-width: 1200px) { ... }
 
 =============*/
+
+
+/* BOOTSTRAP OVERRIDES */
+
+
+code {
+  /* overriden because of accessibility see #714 #740 #741 */
+  font-size: 87.5%;
+  color: #c6005b;
+  word-break: break-word;
+}


### PR DESCRIPTION
resolves #714 #740 #741 #720 #723 #731 

- Override bootstrap style for code element to comply with WCAG 2.0 AA colour contrast standard 