### PR TITLE
Updates to Q1 Strategy

### DIFF
--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -12,7 +12,7 @@ permalink: /strategy-learning-automating-improving.html
 
 The following actions apply for the 1st quarter of the 2020-2021 fiscal year (April 2020 to June 2020).
 
-Strategies and actions will be reviewed and updated quarterly based on effectivness and current progress towards the [Medium Term IT Picture - 2025](it-picture-medium-term.html) as well as following the [Strategy Map](https://sara-sabr.github.io/ITStrategy/strategy-summary.html) (layering on the strategies).
+Strategies and actions will be reviewed and updated quarterly based on effectiveness and current progress towards the [Medium Term IT Picture - 2025](it-picture-medium-term.html) as well as following the [Strategy Map](https://sara-sabr.github.io/ITStrategy/strategy-summary.html) (layering on the strategies).
 
 - [Actions](#actions)
 - [Goals](#goals)

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -12,7 +12,7 @@ permalink: /strategy-learning-automating-improving.html
 
 The following actions apply for the 1st quarter of the 2020-2021 fiscal year (April 2020 to June 2020).
 
-Strategies and actions will be reviewed and updated quarterly based on effectiveness and current progress towards the [Medium Term IT Picture - 2025](it-picture-medium-term.html) as well as following the [Strategy Map](https://sara-sabr.github.io/ITStrategy/strategy-summary.html) (layering on the strategies).
+Strategies and actions will be reviewed and updated quarterly based on effectiveness and current progress towards the [Medium Term IT Picture - 2025](https://sara-sabr.github.io/ITStrategy/it-picture-medium-term.html) as well as following the [Strategy Map](https://sara-sabr.github.io/ITStrategy/strategy-summary.html) (layering on the strategies).
 
 - [Actions](#actions)
 - [Goals](#goals)

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Strategy - Continuous Learning and Improvement
+title: Q1 Strategy - Continuous Learning and Improvement
 ref: strategy-q1-2020
 lang: en
 status: posted
@@ -8,19 +8,20 @@ sections: Ready For Use
 permalink: /strategy-learning-automating-improving.html
 ---
 
-## Strategy - Continuous Learning and Improvement
+## Q1 Strategy - Continuous Learning and Improvement
 
-The following actions apply for the 1st quarter of the 2020-2021 fiscal year.
-Strategies and actions will be reviewed and updated quarterly based on current progress and following the Strategy Map (layering on the strategies).
+The following actions apply for the 1st quarter of the 2020-2021 fiscal year (April 2020 to June 2020).
+
+Strategies and actions will be reviewed and updated quarterly based on effectivness and current progress towards the [Medium Term IT Picture - 2025](it-picture-medium-term.html) as well as following the [Strategy Map](https://sara-sabr.github.io/ITStrategy/strategy-summary.html) (layering on the strategies).
 
 - [Actions](#actions)
 - [Goals](#goals)
 
 ### Actions
 
-All IITB teams must:
+IITB teams should:
 
-#### Use 20% of time to learn and improve
+#### Use up to 20% of time to learn and improve
 
 **For all the following and other related activities, use CATS codes for continuous improvement (######).**
 


### PR DESCRIPTION
Updates before sharing with Director (#534)

- Add Q1 to title of page and details on what Q1 2020 is.
- Links to IT Picture 2025 and Strategy Map.
- Remove ALL and MUST.
- Add "up to" 20%.  Since its now "should" and for teams that can't do 20%

I would like to change the filename and permalink, to remove automating, but the link has already been shared with some groups