### PR TITLE
Fix Pan-Canadian Trust Framework link

### DIFF
--- a/wip-tec/en/ITVision.md
+++ b/wip-tec/en/ITVision.md
@@ -108,7 +108,7 @@ IT solutions managing citizen data are built with a [zero trust architecture](ht
 ESDC's Cyber security has shifted to protecting data at the source and in transit, instead of relying on perimeter defences.
 This involves encrypting data at rest, in transit, and relying on strong authentication, access policies, and modern identity verification to govern access to sensitive data.
 [Behavioral Analytics and biometrics](https://gcn.com/articles/2019/03/25/mobile-verification.aspx) are necessary to secure access to systems and protect citizens from identity theft.
-The [Pan-Canadian Trust Framework](https://canada-ca.github.io/PCTF-CCP/overview/pctf-overview.html) is applied for ESDC's services to enable trusted digital identity to be shared and validated between canadian jurisdictions.
+The [Pan-Canadian Trust Framework](https://canada-ca.github.io/PCTF-CCP/) is applied for ESDC's services to enable trusted digital identity to be shared and validated between canadian jurisdictions.
 
 Cyber security is involved from the beginning of IT solution building to the end, and relies on as much automated testing as possible to provide assurance, as opposed to gate-based assessment processes, and relies on embedded knowledge within development teams instead of analysts.
 

--- a/wip-tec/en/citizen-partners-picture.md
+++ b/wip-tec/en/citizen-partners-picture.md
@@ -45,7 +45,7 @@ These channels may be ESDC's website, the beginning of the GC services portal, S
 - Have access to most services wherever they are, anytime of day
 - Being automatically enrolled to receive benefits without having to apply
 - Automated administrative services like pre-filled applications and program auto-enrollment to save the time it takes to fill out forms and research programs
-- Centralized login for main ESDC services, leveraging existing citizen identities from provincial, territorial, federal and private sector organizations following the [Pan-Canadian Trust Framework](https://github.com/canada-ca/PCTF-CCP/blob/master/overview/pctf-overview.md).
+- Centralized login for main ESDC services, leveraging existing citizen identities from provincial, territorial, federal and private sector organizations following the [Pan-Canadian Trust Framework](https://canada-ca.github.io/PCTF-CCP/).
 - Stronger integration of ESDC and CRA services and the launch of the GC Services Portal.
 - Pages with scrollable instructions outlining details of the application process are a relic of the past.
 


### PR DESCRIPTION
These are old files but PCTF Website was updated with version 1.1 making the build fail