### PR TITLE
Fix anchor scrolling

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -16,7 +16,7 @@ body>.container {
   padding: 60px 10px 0;
 }
 
-.anchor {
+h1, h2, h3, h4, h5, h6 {
   padding-top: 66px;
   margin-top: -66px;
 }

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -17,8 +17,8 @@ body>.container {
 }
 
 .anchor {
-  padding-top: 40px;
-  margin-top: -40px;
+  padding-top: 66px;
+  margin-top: -66px;
 }
 
 /*============= RESETS =============*/

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -15,6 +15,12 @@
 body>.container {
   padding: 60px 10px 0;
 }
+
+.anchor {
+  padding-top: 40px;
+  margin-top: -40px;
+}
+
 /*============= RESETS =============*/
 
 /*-- iPhone X Remove Gutters --*/


### PR DESCRIPTION
Because we have a fixed navbar, linking to an HTML page anchor scrolls too far down (anchor is hidden by navbar).

With this fix, we can link to headers (1-6) and scrolling works as expected. And the new CSS doesn't seem to change the visual aspect of headers.

Open to a better workaround of course :)