### PR TITLE
Fixed logic model image size (to fit in the text width)

### DIFF
--- a/_pages/en/esdc-it-strategy.md
+++ b/_pages/en/esdc-it-strategy.md
@@ -61,7 +61,9 @@ It will do so in an [iterative fashion](https://cloud.google.com/solutions/devop
 
 Because strategy making fosters long-term impacts which are difficult to measure directly, the following IT Strategy Logic Model helps visualize the causes and effects of output activities that are expected to directly affect short term outcomes and lead to long-term impacts.
 
-![ESDC's IT Strategy Logic Model - showing the short, medium, and long-term outcomes](assets/images/it-strategy-logic-model.png "IT Strategy Logic Model")
+<!--markdownlint-disable MD033 -->
+<img src="assets/images/it-strategy-logic-model.png" alt="ESDC's IT Strategy Logic Model - showing the short, medium, and long-term outcomes" height="95%" width="95%">
+<!--markdownlint-enable MD033 -->
 
 The above diagram positions ESDC's IT within its current state of transitioning to Digital Government at the same time as requiring to maintain its legacy systems until they are being replaced with modern ones.
 In addition, the [4 high-level priorities of IITB](http://esdc.prv/en/iitb/corporate/Who_We_Are/Plans_and_Priorities/index.shtml) are listed to remind the focus of the organization.

--- a/_pages/en/esdc-it-strategy.md
+++ b/_pages/en/esdc-it-strategy.md
@@ -62,7 +62,7 @@ It will do so in an [iterative fashion](https://cloud.google.com/solutions/devop
 Because strategy making fosters long-term impacts which are difficult to measure directly, the following IT Strategy Logic Model helps visualize the causes and effects of output activities that are expected to directly affect short term outcomes and lead to long-term impacts.
 
 <!--markdownlint-disable MD033 -->
-<img src="assets/images/it-strategy-logic-model.png" alt="ESDC's IT Strategy Logic Model - showing the short, medium, and long-term outcomes" height="95%" width="95%">
+<img src="assets/images/it-strategy-logic-model.png" alt="ESDC's IT Strategy Logic Model - showing the short, medium, and long-term outcomes" height="100%" width="100%">
 <!--markdownlint-enable MD033 -->
 
 The above diagram positions ESDC's IT within its current state of transitioning to Digital Government at the same time as requiring to maintain its legacy systems until they are being replaced with modern ones.


### PR DESCRIPTION
Somehow using a markdown image tag makes the image too big.... just switching it to an HTML <img> tag even using 100% width/height fixes it...