### PR TITLE
Add Strategy and Analysis sections for Documents page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -19,7 +19,7 @@ description:
   fr: Travailler ouvertement! Nos travaux en cours, liste de documents de références et présentations.
 sectionsList:
   en: ["About us", "Strategies", "Done Enough", "Work In Progress", "Archives"]
-  fr: ["À propos de nous", "Stratégies", "Assez fait", "Travaux en cours", "Archives"]
+  fr: ["À propos de nous", "Stratégies", "Assez fait", "Travail en cours", "Archives"]
 docsTitle:
   en: Documents
   fr: Documents

--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ description:
   en: Working in the open! Our work in progress, list of reference material and presentations.
   fr: Travailler ouvertement! Nos travaux en cours, liste de documents de références et présentations.
 sectionsList:
-  en: ["About us", "Strategies", "Work In Progress", "Archives"]
-  fr: ["À propos de nous", "Stratégies", "Travaux en cours", "Archives"]
+  en: ["About us", "Strategies", "Done Enough", "Work In Progress", "Archives"]
+  fr: ["À propos de nous", "Stratégies", "Assez fait", "Travaux en cours", "Archives"]
 docsTitle:
   en: Documents
   fr: Documents

--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ description:
   en: Working in the open! Our work in progress, list of reference material and presentations.
   fr: Travailler ouvertement! Nos travaux en cours, liste de documents de références et présentations.
 sectionsList:
-  en: ["Vision", "Strategies", "Quarterly Strategies", "About us", "Analysis", "Work In Progress", "Archives"]
-  fr: ["Vision", "Stratégies", "Stratégies trimestrielles", "À propos de nous", "Analyses", "Travail en cours", "Archives"]
+  en: ["Vision", "Strategies", "Quarterly Strategies", "About us", "Analysis", "Work In Progress"]
+  fr: ["Vision", "Stratégies", "Stratégies trimestrielles", "À propos de nous", "Analyses", "Travail en cours"]
 docsTitle:
   en: Documents
   fr: Documents

--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ description:
   en: Working in the open! Our work in progress, list of reference material and presentations.
   fr: Travailler ouvertement! Nos travaux en cours, liste de documents de références et présentations.
 sectionsList:
-  en: ["Vision", "Strategies", "Quarterly Strategies", "About us", "Work In Progress", "Archives"]
-  fr: ["Vision", "Stratégies", "Stratégies trimestrielles", "À propos de nous", "Travail en cours", "Archives"]
+  en: ["Vision", "Strategies", "Quarterly Strategies", "About us", "Analysis", "Work In Progress", "Archives"]
+  fr: ["Vision", "Stratégies", "Stratégies trimestrielles", "À propos de nous", "Analyses", "Travail en cours", "Archives"]
 docsTitle:
   en: Documents
   fr: Documents

--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ description:
   en: Working in the open! Our work in progress, list of reference material and presentations.
   fr: Travailler ouvertement! Nos travaux en cours, liste de documents de références et présentations.
 sectionsList:
-  en: ["About us", "Ready For Use", "Trends", "Under Review", "Work In Progress", "Archives"]
-  fr: ["À propos de nous", "Prêt à utiliser", "Tendances", "En révision", "Travaux en cours", "Archives"]
+  en: ["About us", "Strategies", "Work In Progress", "Archives"]
+  fr: ["À propos de nous", "Stratégies", "Travaux en cours", "Archives"]
 docsTitle:
   en: Documents
   fr: Documents

--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ description:
   en: Working in the open! Our work in progress, list of reference material and presentations.
   fr: Travailler ouvertement! Nos travaux en cours, liste de documents de références et présentations.
 sectionsList:
-  en: ["About us", "Strategies", "Ready For Use", "Work In Progress", "Archives"]
-  fr: ["À propos de nous", "Stratégies", "Prêt à utiliser", "Travail en cours", "Archives"]
+  en: ["Vision", "Strategies", "Quarterly Strategies", "About us", "Work In Progress", "Archives"]
+  fr: ["Vision", "Stratégies", "Stratégies trimestrielles", "À propos de nous", "Travail en cours", "Archives"]
 docsTitle:
   en: Documents
   fr: Documents

--- a/_config.yml
+++ b/_config.yml
@@ -18,8 +18,8 @@ description:
   en: Working in the open! Our work in progress, list of reference material and presentations.
   fr: Travailler ouvertement! Nos travaux en cours, liste de documents de références et présentations.
 sectionsList:
-  en: ["About us", "Strategies", "Done Enough", "Work In Progress", "Archives"]
-  fr: ["À propos de nous", "Stratégies", "Assez fait", "Travail en cours", "Archives"]
+  en: ["About us", "Strategies", "Ready For Use", "Work In Progress", "Archives"]
+  fr: ["À propos de nous", "Stratégies", "Prêt à utiliser", "Travail en cours", "Archives"]
 docsTitle:
   en: Documents
   fr: Documents

--- a/_pages/en/esdc-it-strategy.md
+++ b/_pages/en/esdc-it-strategy.md
@@ -4,7 +4,7 @@ title: ESDC IT Strategy
 ref: esdc-it-strategy
 lang: en
 status: posted
-sections: Ready For Use
+sections: Strategies
 permalink: /esdc-it-strategy.html
 ---
 

--- a/_pages/en/human-development-life-cycle.md
+++ b/_pages/en/human-development-life-cycle.md
@@ -4,7 +4,7 @@ title: Human Development Life Cycle
 ref: hdlc
 lang: en
 status: posted
-sections: Ready For Use
+sections: Vision
 permalink: /human-development-life-cycle.html
 ---
 

--- a/_pages/en/human-development-life-cycle.md
+++ b/_pages/en/human-development-life-cycle.md
@@ -4,7 +4,7 @@ title: Human Development Life Cycle
 ref: hdlc
 lang: en
 status: posted
-sections: Work In Progress
+sections: Done Enough
 permalink: /human-development-life-cycle.html
 ---
 

--- a/_pages/en/human-development-life-cycle.md
+++ b/_pages/en/human-development-life-cycle.md
@@ -4,7 +4,7 @@ title: Human Development Life Cycle
 ref: hdlc
 lang: en
 status: posted
-sections: Done Enough
+sections: Ready For Use
 permalink: /human-development-life-cycle.html
 ---
 

--- a/_pages/en/it-picture-long-term.md
+++ b/_pages/en/it-picture-long-term.md
@@ -4,7 +4,7 @@ title: IT Picture - Long Term
 ref: it-picture-long-term
 lang: en
 status: posted
-sections: Ready For Use
+sections: Strategies
 permalink: /it-picture-long-term.html
 ---
 

--- a/_pages/en/it-picture-long-term.md
+++ b/_pages/en/it-picture-long-term.md
@@ -4,7 +4,7 @@ title: IT Picture - Long Term
 ref: it-picture-long-term
 lang: en
 status: posted
-sections: Strategies
+sections: Done Enough
 permalink: /it-picture-long-term.html
 ---
 

--- a/_pages/en/it-picture-long-term.md
+++ b/_pages/en/it-picture-long-term.md
@@ -4,7 +4,7 @@ title: IT Picture - Long Term
 ref: it-picture-long-term
 lang: en
 status: posted
-sections: Ready For Use
+sections: Vision
 permalink: /it-picture-long-term.html
 ---
 

--- a/_pages/en/it-picture-long-term.md
+++ b/_pages/en/it-picture-long-term.md
@@ -4,7 +4,7 @@ title: IT Picture - Long Term
 ref: it-picture-long-term
 lang: en
 status: posted
-sections: Done Enough
+sections: Ready For Use
 permalink: /it-picture-long-term.html
 ---
 

--- a/_pages/en/it-picture-medium-term.md
+++ b/_pages/en/it-picture-medium-term.md
@@ -4,7 +4,7 @@ title: IT Picture - Medium Term
 ref: it-picture-medium-term
 lang: en
 status: posted
-sections: Strategies
+sections: Done Enough
 permalink: /it-picture-medium-term.html
 ---
 

--- a/_pages/en/it-picture-medium-term.md
+++ b/_pages/en/it-picture-medium-term.md
@@ -4,7 +4,7 @@ title: IT Picture - Medium Term
 ref: it-picture-medium-term
 lang: en
 status: posted
-sections: Ready For Use
+sections: Vision
 permalink: /it-picture-medium-term.html
 ---
 

--- a/_pages/en/it-picture-medium-term.md
+++ b/_pages/en/it-picture-medium-term.md
@@ -4,7 +4,7 @@ title: IT Picture - Medium Term
 ref: it-picture-medium-term
 lang: en
 status: posted
-sections: Done Enough
+sections: Ready For Use
 permalink: /it-picture-medium-term.html
 ---
 

--- a/_pages/en/it-picture-medium-term.md
+++ b/_pages/en/it-picture-medium-term.md
@@ -4,7 +4,7 @@ title: IT Picture - Medium Term
 ref: it-picture-medium-term
 lang: en
 status: posted
-sections: Ready For Use
+sections: Strategies
 permalink: /it-picture-medium-term.html
 ---
 

--- a/_pages/en/strategies-actions.md
+++ b/_pages/en/strategies-actions.md
@@ -4,7 +4,7 @@ title: IT Strategies and Actions
 ref: strategies
 lang: en
 status: posted
-sections: Archives
+sections: Strategies
 permalink: /strategies-actions.html
 ---
 

--- a/_pages/en/strategies-actions.md
+++ b/_pages/en/strategies-actions.md
@@ -4,7 +4,7 @@ title: IT Strategies and Actions
 ref: strategies
 lang: en
 status: posted
-sections: Done Enough
+sections: Archives
 permalink: /strategies-actions.html
 ---
 

--- a/_pages/en/strategies-actions.md
+++ b/_pages/en/strategies-actions.md
@@ -4,7 +4,7 @@ title: IT Strategies and Actions
 ref: strategies
 lang: en
 status: posted
-sections: Ready For Use
+sections: Strategies
 permalink: /strategies-actions.html
 ---
 

--- a/_pages/en/strategies-actions.md
+++ b/_pages/en/strategies-actions.md
@@ -4,7 +4,7 @@ title: IT Strategies and Actions
 ref: strategies
 lang: en
 status: posted
-sections: Strategies
+sections: Done Enough
 permalink: /strategies-actions.html
 ---
 

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -4,7 +4,7 @@ title: Q1 Strategy - Continuous Improvement and Learning
 ref: strategy-q1-2020
 lang: en
 status: posted
-sections: Ready For Use
+sections: Strategies
 permalink: /strategy-learning-automating-improving.html
 ---
 

--- a/_pages/en/strategy-learning-automating-improving.md
+++ b/_pages/en/strategy-learning-automating-improving.md
@@ -4,7 +4,7 @@ title: Q1 Strategy - Continuous Improvement and Learning
 ref: strategy-q1-2020
 lang: en
 status: posted
-sections: Strategies
+sections: Quarterly Strategies
 permalink: /strategy-learning-automating-improving.html
 ---
 

--- a/_pages/en/strategy-summary.md
+++ b/_pages/en/strategy-summary.md
@@ -4,7 +4,7 @@ title: Strategy Map
 ref: summary
 lang: en
 status: posted
-sections: Ready For Use
+sections: Strategies
 permalink: /strategy-summary.html
 ---
 

--- a/_pages/fr/sommaire-strategie.md
+++ b/_pages/fr/sommaire-strategie.md
@@ -4,7 +4,7 @@ title: Carte de stratégies
 ref: summary
 lang: fr
 status: posted
-sections: Prêt à utiliser
+sections: Stratégies
 permalink: /sommaire-strategie.html
 ---
 

--- a/_pages/fr/tendances.md
+++ b/_pages/fr/tendances.md
@@ -4,7 +4,7 @@ title: Tendances et besoins futurs
 ref: trends
 lang: fr
 status: posted
-sections: Travaux en cours
+sections: Archives
 permalink: /tendances.html
 ---
 


### PR DESCRIPTION
Closes #844 

This replaces "Ready for use" with a "Strategies" category on the Documents page.

I also added a "Done Enough" category.

I archived the Strategies and Actions page.  are there other pages we could move from "Work in Progress" to "Archive"?