### PR TITLE
Readd About us to menu

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,6 +11,12 @@
       <!-- Menu -->
       <ul class="navbar-nav ml-auto">
         <!--About Us - A propos de nous-->
+        {%- assign dropdown_section=site.sectionsList[page.lang][3]-%}
+        {%- assign dropdown_title=dropdown_section-%}
+        {%- assign dropdown_id = "navbarDropdownAbout" -%}
+        {% include dropdown.html %}
+
+        <!--Vison-->
         {%- assign dropdown_section=site.sectionsList[page.lang][0]-%}
         {%- assign dropdown_title=dropdown_section-%}
         {%- assign dropdown_id = "navbarDropdownAbout" -%}


### PR DESCRIPTION
About us disapeared from the menu (became Vision) during the reorg of sections on the site.

PR adds it back.

This is what it looks like
![image](https://user-images.githubusercontent.com/2353299/77465924-d2cce780-6ddf-11ea-9bea-6af31b946678.png)

