### PR TITLE
Add temporary exception to surveymonkey

### DIFF
--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -80,6 +80,9 @@
     },
     {
       "pattern": "https://www.tpsgc-pwgsc.gc.ca/app-acq/cral-sarc/lgcl-ctgr-eng.html"
+    },
+    {
+      "pattern": "https://www.surveymonkey.com"
     }
   ]
 }

--- a/.markdown-link-check.json
+++ b/.markdown-link-check.json
@@ -70,7 +70,7 @@
       "pattern": "https://www.pcloud.com"
     },
     {
-      "pattern": "https://pm.gc.ca/en/mandate-letters/minister-digital-government-mandate-letter"
+      "pattern": "https://pm.gc.ca/"
     },
     {
       "pattern": "http://srmis-sigdi-iagent.prv"      


### PR DESCRIPTION
Temporary fix the link tests failing with surveymonkey (down for maintenance) and pm.gc.ca (no server response?).

Reverse fix will need to be performed shortly