### PR TITLE
Fix URL pointing to Programme

### DIFF
--- a/_pages/en/strategy-target-solution-delivery-model.md
+++ b/_pages/en/strategy-target-solution-delivery-model.md
@@ -104,7 +104,7 @@ Stakeholders are expected to still comply with existing policy instruments inclu
 
 - ESDC [Policy on Project and Programme Management (PPPM)](https://gpp-ppm.service.gc.ca/sites/pwa/ESDCKnowledgeRepository/All%20Documents/Policy%20on%20Project%20and%20Programme%20Management.pdf)
 - ESDC [Directive on Programme Management](https://gpp-ppm.service.gc.ca/sites/pwa/ESDCKnowledgeRepository/All%20Documents/Directive%20On%20Programme%20Management.pdf)
-- ESDC [Directive on Project Management](https://gpp-ppm.service.gc.ca/sites/pwa/ESDCKnowledgeRepository/All%20Documents/Directive%20On%20Programme%20Management.pdf)
+- ESDC [Directive on Project Management](https://gpp-ppm.service.gc.ca/sites/pwa/ESDCKnowledgeRepository/All%20Documents/Directive%20On%20Project%20Management.pdf)
 - ESDC Information Management Policy (being drafted)
 - ESDC [Procurement Policies](http://iservice.prv/eng/finance/purchasing/policy.shtml)
 - ESDC Security Policy (being drafted)


### PR DESCRIPTION
There was a link supposed to be pointing to Directive on Project Management that was leading to the Programme Management instead.

Fixes that issue.