### PR TITLE
Enable website analytics IP anonymization

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -17,7 +17,7 @@
     window.dataLayer = window.dataLayer || [];
     function gtag() { dataLayer.push(arguments); }
     gtag('js', new Date());
-    gtag('config', 'UA-152866056-1');
+    gtag('config', 'UA-152866056-1', { 'anonymize_ip': true });
   </script>
 
   <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css"


### PR DESCRIPTION
More details from Google if you are interested: [IP Anonymization (or IP masking) in Analytics](https://support.google.com/analytics/answer/2763052)

Related to #296