### PR TITLE
Add page redirect functionality to site

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,3 +12,6 @@ url: "https://sara-sabr.github.io/"
 markdown: kramdown
 include: ["_pages"]
 exclude: ["wip-tec", "CONTRIBUTING.md", "cspell.json", "LICENSE", "link-check.js", "package.json", "package-lock.json", "README.md", "node_modules"]
+
+plugins:
+  - jekyll-redirect-from

--- a/_includes/page-redirect.md
+++ b/_includes/page-redirect.md
@@ -1,0 +1,1 @@
+{{ site.data.i18n.general.thisPageHasMoved[page.lang] }} {{page.title}}


### PR DESCRIPTION
these changes required in order to add a redirect on the old Micro-procurement page (to point to the new Micro-Acquisition page).