### PR TITLE
Change MathJax CDN to jsdelivr

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -34,7 +34,7 @@
     href="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.19/css/dataTables.bootstrap4.min.css">
 
   <!-- Mathjax Support -->
-  <script type="text/javascript" id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
+  <script type="text/javascript" id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-MML-AM_CHTML">
   </script>
 
-  </head>
+</head>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -34,7 +34,7 @@
     href="https://cdnjs.cloudflare.com/ajax/libs/datatables/1.10.19/css/dataTables.bootstrap4.min.css">
 
   <!-- Mathjax Support -->
-  <script async src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_CHTML">
+  <script type="text/javascript" id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-mml-chtml.js">
   </script>
 
   </head>


### PR DESCRIPTION
Closes #1401 

Quick fix to remove warning about mathjax cdn being retired (since 2017).