### PR TITLE
Add a 'How we are minimizing risks' section to MA page

### DIFF
--- a/_pages/en/micro-acquisition-pilot.md
+++ b/_pages/en/micro-acquisition-pilot.md
@@ -36,6 +36,18 @@ Run a one-year experimental pilot for purchases of $10K or less for custom code 
 - Increased ESDC capabilities around agile, including breaking work up into smaller chunks which drive high software delivery and organizational performance
 - Increased speed of payment of suppliers
 
+## How We Are Minimizing Risk
+
+- This is initiative is being co-sponsored by IITB and CFOB
+- We aren't changing any procurement or finance rules. Existing safeguards such as section 32 and 34 approval remain in place.
+- We are working with our CFOB partners to put in place:
+  - guardrails to protect against contract splitting
+  - a short legal document to address Intellectual Property rights for purchases made via the Micro-Acquisition pilot
+- We are working with colleagues in IITB to establish and document procedures to verify the quality of the code that is purchased via Micro-Acquisition (including the automation of testing using OSS tools/CLI).
+- We are developing and testing the draft Micro-Acquisition process with our stakeholders (CFOB procurement, CFOB acquisition card team, IITB finance team and the Office of Small and Medium Enterprise at PSPC)
+- We are taking lessons learned from others who have done similar micro-procurement initiatives (the [BC Developers Exchange](https://bcdevexchange.org/)/[BC Digital Marketplace](https://digital.gov.bc.ca/marketplace), US government, Industry, the [GCDevelopers Exchange](https://github.com/canada-ca/devex))
+- We will be requiring that all code that is purchased via micro-acquisition is documented on the [Open Resource Exchange](https://code.open.canada.ca/en/index.html) so that it is findable and to facilitate code re-use.
+
 ## Additional Materials  
 
 - [Presentation]({{ site.baseurl }}/presentation.html?markdown=en/2020-Micro-Acquisition-Pilot.md)


### PR DESCRIPTION
Added some content to this page to help address the 'what about' questions we often hear with Micro-Acquisition.  Thinking about also adding links to some of the pieces (e.g. the draft one page IP document and the draft processes). 

Interested in your thoughts.. does this capture the things you have heard/been asked most about MA?