### PR TITLE
Fix presentations in IE

### DIFF
--- a/_includes/footer-revealjs.html
+++ b/_includes/footer-revealjs.html
@@ -3,6 +3,23 @@
 <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.0.2/plugin/notes/notes.js"></script>
 
 <script>
+(function (w) {
+
+w.URLSearchParams = w.URLSearchParams || function (searchString) {
+	var self = this;
+	self.searchString = searchString;
+	self.get = function (name) {
+		var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(self.searchString);
+		if (results == null) {
+			return null;
+		}
+		else {
+			return decodeURI(results[1]) || 0;
+		}
+	};
+}
+})(window)
+
 var params = new URLSearchParams(window.location.search);
 if (params.get("print-pdf") !== null)
 {

--- a/_pages/presentation.html
+++ b/_pages/presentation.html
@@ -10,6 +10,7 @@ permalink: /presentation.html
 </section>
 
 <script>
+
 function getUrlVars() {
     var vars = {};
     var parts = window.location.href.replace(/[?&]+([^=&]+)=([^&]*)/gi, function(m,key,value) {
@@ -56,5 +57,18 @@ else{
 
 document.getElementsByTagName("head")[0].appendChild(title)
 document.getElementById("markdown-slides").setAttribute("data-markdown", "./presentations/" + markdown);
+
+if(/MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
+  if ( markdown.match("fr/")){
+    alert("Nous recommandons d'utiliser Edge, Firefox et autres navigateurs modernes au lieu d'Internet Explorer. Nous allons maintenant ouvrir ce site dans Edge pour une expérience optimale.")
+  }
+  else{
+    alert("We recommend Edge, Firefox and other modern browsers instead of Internet Explorer. We'll now open this website in Edge for an optimal experience.")  
+  }
+  window.location = 'microsoft-edge:' + window.location;
+  setTimeout(function() {
+    window.location = 'https://go.microsoft.com/fwlink/?linkid=2135547';
+  }, 1);
+}
 
 </script>

--- a/_pages/presentation.html
+++ b/_pages/presentation.html
@@ -63,7 +63,7 @@ if(/MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
     alert("Nous recommandons d'utiliser Edge, Firefox et autres navigateurs modernes au lieu d'Internet Explorer. Nous allons maintenant ouvrir ce site dans Edge pour une expérience optimale.")
   }
   else{
-    alert("We recommend Edge, Firefox and other modern browsers instead of Internet Explorer. We'll now open this website in Edge for an optimal experience.")  
+    alert("We recommend to use Edge, Firefox and other modern browsers instead of Internet Explorer. We'll now open this website in Edge for an optimal experience.")  
   }
   window.location = 'microsoft-edge:' + window.location;
   setTimeout(function() {

--- a/_pages/presentation.html
+++ b/_pages/presentation.html
@@ -68,7 +68,7 @@ if(/MSIE \d|Trident.*rv:/.test(navigator.userAgent)) {
   window.location = 'microsoft-edge:' + window.location;
   setTimeout(function() {
     window.location = 'https://go.microsoft.com/fwlink/?linkid=2135547';
-  }, 1);
+  }, 500);
 }
 
 </script>


### PR DESCRIPTION
You can test in my fork (as Jekyll doesn't render presentations locally correctly anyway):
https://gabrielcossette.github.io/ITStrategy/presentations.html

Explanation: The native Web API "URLSearchParams" isn't supported by Internet Explorer.

I replaced it with a "[polyfill](https://en.wikipedia.org/wiki/Polyfill_(programming))" I found (while learning what is a polyfill at the same time 😄)

Fixes #1628