### PR TITLE
Change blogue for billet

### DIFF
--- a/_data/i18n/general.yml
+++ b/_data/i18n/general.yml
@@ -81,10 +81,10 @@ blogs:
     fr: Traduit le
   previous:
     en: Previous blog
-    fr: Blogue précédent
+    fr: Billet précédent
   next:
     en: Next blog
-    fr: Prochain blogue
+    fr: Prochain billet
 
 about:
   interests:


### PR DESCRIPTION
As mentioned, I believe `Blogue précédent` and `Prochain blogue` actually be `Billet précédent` and `Prochain billet`

Refs: 
- http://bdl.oqlf.gouv.qc.ca/BDL/gabarit_bdl.asp?id=5383
- http://bdl.oqlf.gouv.qc.ca/BDL/gabarit_bdl.asp?id=4925