### PR TITLE
Resources page changes

### DIFF
--- a/_data/tables/references.yml
+++ b/_data/tables/references.yml
@@ -13,19 +13,19 @@
             items:
               - item:
                   fr: |
-                    <a href="http://esdc.prv/fr/ministere/pai/index.shtml" target="_blank">Cadre stratégique d’EDSC</a>
+                    <a href="http://esdc.prv/fr/ministere/pai/index.shtml" target="_blank">Cadre stratégique d’EDSC (réseau EDSC)</a>
                   en: |
-                    <a href="http://esdc.prv/en/department/ibp/index.shtml" target="_blank">ESDC strategic Framework</a>
+                    <a href="http://esdc.prv/en/department/ibp/index.shtml" target="_blank">ESDC strategic Framework (ESDC Network)</a>
               - item:
                   fr: |
-                    <a href="http://esdc.prv/fr/ministere/service-strategique/index.shtml" target="_blank">Stratégie de transformation de service d’ESDC</a>
+                    <a href="http://esdc.prv/fr/ministere/service-strategique/index.shtml" target="_blank">Stratégie de transformation de service d’ESDC (réseau EDSC)</a>
                   en: |
-                    <a href="http://esdc.prv/en/department/service-strategy/index.shtml" target="_blank">ESDC Service transformation Strategy</a>
+                    <a href="http://esdc.prv/en/department/service-strategy/index.shtml" target="_blank">ESDC Service transformation Strategy (ESDC Network)</a>
               - item:
                   fr: |
-                    <a href="http://esdc.prv/fr/ministere/changements_lmdes.shtml" target="_blank">Changements récents au mandat d’EDSC</a>
+                    <a href="http://esdc.prv/fr/ministere/changements_lmdes.shtml" target="_blank">Changements récents au mandat d’EDSC (réseau EDSC)</a>
                   en: |
-                    <a href="http://esdc.prv/en/department/changes_desda.shtml" target="_blank">Recent changes to the ESDC's mandate</a>
+                    <a href="http://esdc.prv/en/department/changes_desda.shtml" target="_blank">Recent changes to the ESDC's mandate (ESDC Network)</a>
               - item:
                   fr: |
                     <a href="https://www.canada.ca/fr/emploi-developpement-social/ministere/rapports/plan-ministeriel.html" target="_blank">Plans ministériels d’EDSC</a>
@@ -33,34 +33,34 @@
                     <a href="https://www.canada.ca/en/employment-social-development/corporate/reports/departmental-plan.html" target="_blank">ESDC's departmental plans</a>
               - item:
                   fr: |
-                    <a href="http://dialogue/grp/WM-Gde/Operational%20Staffing%20Plan/PMD%20OSP%20Library/2018-19_Operational_Staffing_Plan_IITB.docx" target="_blank">Plan opérationnel de dotation de la DGIIT à EDSC</a> (Anglais - Interne)
+                    <a href="http://dialogue/grp/WM-Gde/Operational%20Staffing%20Plan/PMD%20OSP%20Library/2018-19_Operational_Staffing_Plan_IITB.docx" target="_blank">Plan opérationnel de dotation de la DGIIT à EDSC</a> (Anglais - réseau EDSC)
                   en: |
-                    <a href="http://dialogue/grp/WM-Gde/Operational%20Staffing%20Plan/PMD%20OSP%20Library/2018-19_Operational_Staffing_Plan_IITB.docx" target="_blank">ESDC's IITB Operational Staffing Plan 2018-2019 (Internal)</a>
+                    <a href="http://dialogue/grp/WM-Gde/Operational%20Staffing%20Plan/PMD%20OSP%20Library/2018-19_Operational_Staffing_Plan_IITB.docx" target="_blank">ESDC's IITB Operational Staffing Plan 2018-2019 (ESDC Network)</a>
               - item:
                   fr: |
-                    <a href="http://iservice.prv/fra/si/securite/outils_et_ressources/trousse_outils/edsc_directive_utilisation_reseau.shtml" target="_blank">Directive sur l’utilisation du réseau d’EDSC</a>
+                    <a href="http://iservice.prv/fra/si/securite/outils_et_ressources/trousse_outils/edsc_directive_utilisation_reseau.shtml" target="_blank">Directive sur l’utilisation du réseau d’EDSC (réseau EDSC)</a>
                   en: |
                     <a href="http://iservice.prv/eng/is/security/tools_and_resources/toolkit/network_use_directive.shtml" target="_blank">ESDC Network Use Directive</a>
               - item:
                   fr: |
-                    <a href="http://iservice.prv/fra/si/securite/classification/outil_classification.shtml" target="_blank">Outil de classification de l’information d’EDSC</a>
+                    <a href="http://iservice.prv/fra/si/securite/classification/outil_classification.shtml" target="_blank">Outil de classification de l’information d’EDSC (réseau EDSC)</a>
                   en: |
-                    <a href="http://iservice.prv/eng/is/security/classification/classification_tool.shtml" target="_blank">ESDC Information Classification Tool</a>
+                    <a href="http://iservice.prv/eng/is/security/classification/classification_tool.shtml" target="_blank">ESDC Information Classification Tool (ESDC Network)</a>
               - item:
                   fr: |
-                    <a href="http://esdc.prv/fr/restez_branche/medias_sociaux.shtml" target="_blank">Guide d’utilisation des médias sociaux à l’intention des employés d’EDSC</a>
+                    <a href="http://esdc.prv/fr/restez_branche/medias_sociaux.shtml" target="_blank">Guide d’utilisation des médias sociaux à l’intention des employés d’EDSC (réseau EDSC)</a>
                   en: |
-                    <a href="http://esdc.prv/en/stay_connected/social_media.shtml" target="_blank">ESDC Social Media Guidelines for Employees</a>
+                    <a href="http://esdc.prv/en/stay_connected/social_media.shtml" target="_blank">ESDC Social Media Guidelines for Employees (ESDC Network)</a>
               - item:
                   fr: |
-                    <a href="http://esdc.prv/fr/restez_branche/manuel.shtml" target="_blank">Guide sur l’utilisation personnelle et officielle d’Internet d’EDSC</a>
+                    <a href="http://esdc.prv/fr/restez_branche/manuel.shtml" target="_blank">Guide sur l’utilisation personnelle et officielle d’Internet d’EDSC (réseau EDSC)</a>
                   en: |
-                    <a href="http://esdc.prv/en/stay_connected/handbook.shtml" target="_blank">ESDC Handbook for the Personal and Official Use of the Internet</a>
+                    <a href="http://esdc.prv/en/stay_connected/handbook.shtml" target="_blank">ESDC Handbook for the Personal and Official Use of the Internet (ESDC Network)</a>
               - item:
                   fr: |
-                    <a href="http://dialogue/grp/ITSecurity-SecuriteTI/Site/Exceptions.aspx" target="_blank">Demandes d’exception de sécurité TI d’EDSC</a>
+                    <a href="http://dialogue/grp/ITSecurity-SecuriteTI/Site/Exceptions.aspx" target="_blank">Demandes d’exception de sécurité TI d’EDSC (réseau EDSC)</a>
                   en: |
-                    <a href="http://dialogue/grp/ITSecurity-SecuriteTI/Site/Exceptions.aspx" target="_blank">ESDC IT Security Exception Requests</a>
+                    <a href="http://dialogue/grp/ITSecurity-SecuriteTI/Site/Exceptions.aspx" target="_blank">ESDC IT Security Exception Requests (ESDC Network)</a>
               - item:
                   fr: |
                     <a href="https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=32588" target="_blank">Orientation sur l’habilitation de l’accès aux services Web : Avis de mise en œuvre de la politique</a>
@@ -80,14 +80,14 @@
                   fr: |
                     <a href="https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=32603" target="_blank">Politique sur les services et le numérique du CT</a> <a href="https://gccollab.ca/groups/profile/588431/endigital-numu00e9riquefrdigital-numu00e9rique" target="_blank">(GCCollab group)</a>
                   en: |
-                    <a href="http://dialogue/grp/BU6810070/Shared%20Documents/Reference%20Materials/Policy%20on%20service%20and%20digital.docx" target="_blank">TB Policy on service and digital</a>
+                    <a href="http://dialogue/grp/BU6810070/Shared%20Documents/Reference%20Materials/Policy%20on%20service%20and%20digital.docx" target="_blank">TB Policy on service and digital (ESDC Network, English only)</a>
                     <br>
                     (<a href="https://gccollab.ca/groups/profile/588431/endigital-numu00e9riquefrdigital-numu00e9rique" target="_blank">GCCollab group</a>)
               - item:
                   fr: |
                     <a href="https://www.tbs-sct.gc.ca/pol/doc-fra.aspx?id=32601" target="_blank">Directive sur les services et le numérique du CT</a> <a href="https://gccollab.ca/groups/profile/588431/endigital-numu00e9riquefrdigital-numu00e9rique" target="_blank">(GCCollab group)</a>
                   en: |
-                    <a href="http://dialogue/grp/BU6810070/Shared%20Documents/Reference%20Materials/Directive%20on%20service%20and%20digital.docx" target="_blank">TB Directive on service and digital</a>
+                    <a href="http://dialogue/grp/BU6810070/Shared%20Documents/Reference%20Materials/Directive%20on%20service%20and%20digital.docx" target="_blank">TB Directive on service and digital (ESDC Network, English only)</a>
                     <br>
                     (<a href="https://gccollab.ca/groups/profile/588431/endigital-numu00e9riquefrdigital-numu00e9rique" target="_blank">GCCollab group</a>)
               - item:

--- a/_data/tables/references.yml
+++ b/_data/tables/references.yml
@@ -2585,7 +2585,7 @@
           data:
             list: false
             fr: <a href="https://www.goodreads.com/en/book/show/1523368.Project_Retrospectives" target="_blank">Project Retrospectives</a>
-            en:
+            en: <a href="https://www.goodreads.com/en/book/show/1523368.Project_Retrospectives" target="_blank">Project Retrospectives</a>
         - col:
           data:
             list: false
@@ -3009,7 +3009,7 @@
           data:
             list: false
             fr: <a href="https://projecttoproduct.org/" target="_blank">Project to Product</a>
-            en:
+            en: <a href="https://projecttoproduct.org/" target="_blank">Project to Product</a>
         - col:
           data:
             list: false

--- a/_pages/en/resources.md
+++ b/_pages/en/resources.md
@@ -13,8 +13,6 @@ The following are reference materials for the IT Strategy team to use.
 
 These materials are meant to be sources of inspiration, guidance, or policies that we need to consider when crafting our strategies.
 
-Some of that content may only be available on GC/ESDC network so if the link doesn't work externally, we apologize for the inconvenience.
-
 Don't hesitate to send us proposals of books, articles, videos or even policies!
 
 ## {{ tables[0].name[page.lang] }}

--- a/_pages/fr/ressources.md
+++ b/_pages/fr/ressources.md
@@ -12,8 +12,6 @@ Le matériel de référence présent sur cette page est utilisé par l'équipe d
 
 Ces références ont comme objectif de servir d'inspiration, de guide ou sont même des politiques qui doivent être considérées lors de la création de nos stratégies.
 
-Certain du contenu pourrait être disponible uniquement sur le réseau du GC/EDSC, alors nous nous excusons si des liens ne fonctionnent pas à l'externe.
-
 N'hésitez pas à nous envoyer des propositions de livres, articles, vidéos ou même des politiques!
 
 ## {{ tables[0].name[page.lang] }}


### PR DESCRIPTION
closing #1629 
Resources page:
@smellems   can you please add to each link that is only ESDC network ‘ESDC network’ label.
and if a link is only in English add ‘english only’ and ‘anglais seulement’ to the french page just like you did with strategies and initiatives pages. 