### PR TITLE
Create micro-acquisition issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/micro-acquisition
+++ b/.github/ISSUE_TEMPLATE/micro-acquisition
@@ -1,0 +1,8 @@
+---
+name: Micro-acquisition
+about: Issues related to the micro-acquisition pilot - Tâches liées au Pilote de micro-acquisition
+title: 'MA - '
+labels: Micro-acquisitions
+assignees: rachelmuston
+
+---


### PR DESCRIPTION
Saw that @gcharest had created a template for the joint council work and thought it would be awesome to have a template for MA issues.