### PR TITLE
Update issue templates - adding MA template

### DIFF
--- a/.github/ISSUE_TEMPLATE/micro-acquisition.md
+++ b/.github/ISSUE_TEMPLATE/micro-acquisition.md
@@ -1,6 +1,6 @@
 ---
 name: Micro-acquisition
-about: Describe this issue template's purpose here.
+about: Issues related to the micro-acquisition pilot - Tâches liées au Pilote de micro-acquisition
 title: 'MA - '
 labels: micro-acquisitions
 assignees: RachelMuston

--- a/.github/ISSUE_TEMPLATE/micro-acquisition.md
+++ b/.github/ISSUE_TEMPLATE/micro-acquisition.md
@@ -1,0 +1,10 @@
+---
+name: Micro-acquisition
+about: Describe this issue template's purpose here.
+title: 'MA - '
+labels: micro-acquisitions
+assignees: RachelMuston
+
+---
+
+


### PR DESCRIPTION
I created a template last week for MA issues but the template isn't showing up in the 'New Issues' page (but it can be found by clicking on 'Edit Templates'). Hoping this PR adds it to the New Issues page (this time I created it via settings directly on the New Issues page). FYI I don't know what I'm doing. lol