### PR TITLE
remove time from the RUN_DATE variable

### DIFF
--- a/.github/workflows/github-project-export.yml
+++ b/.github/workflows/github-project-export.yml
@@ -8,7 +8,7 @@ jobs:
     steps:
       - name: Setup Date Variable
         id: date
-        run: echo "::set-output name=RUN_DATE::$(date +'%Y-%m-%dT%H:%M:%S')"
+        run: echo "::set-output name=RUN_DATE::$(date +'%Y-%m-%d')"
       - name: Checkout Repository
         uses: actions/checkout@v2
       - name: Install Dependencies


### PR DESCRIPTION
Having time in the file name adds multiple : to the filename which causes problems with windows machines running local clones