### PR TITLE
broken link flagged as 404

### DIFF
--- a/presentations/en/SLF.md
+++ b/presentations/en/SLF.md
@@ -27,7 +27,7 @@ Note:
 - Banks are training investment bankers to code. From Financial Times and Wall Street Journal.
 
   - E.g. Citigroup traders get a 3-day Python course. JPMorgan Chase 300 analysts mandatory Python programming courses.
-  - Source: https://www.techrepublic.com/article/why-big-banks-are-requiring-workers-to-learn-coding/
+  - Source: (404) techrepublic.com/article/why-big-banks-are-requiring-workers-to-learn-coding/
 - Windows operating system has 60 million lines of code
 - In 2010 cars already contained around one hundred million
   - Source: [Project to Product, Mik Kersten](https://projecttoproduct.org/)

--- a/presentations/fr/SLF.md
+++ b/presentations/fr/SLF.md
@@ -27,7 +27,7 @@ Note:
 - Les banques forment leurs banquiers à coder. Du Financial Times et Wall Street Journal.
   - e.g. Citigroup donne un cours de 3 jours à leurs banquiers pour qu'ils apprennent Python
   - e.g. JPMorgan Chase a un cours obligatoire sur Python pour ses 300 analystes
-  - Source: https://www.techrepublic.com/article/why-big-banks-are-requiring-workers-to-learn-coding/
+  - Source: (404) techrepublic.com/article/why-big-banks-are-requiring-workers-to-learn-coding/
 - Les voitures ont maintenant des centaines de millions de lignes de codes.
   - Source: https://www.technologyreview.com/s/508231/many-cars-have-a-hundred-million-lines-of-code/
 


### PR DESCRIPTION
removing broken links from files. Keeping the URL in comments but mentioning the 404 error to the markdown author.