### PR TITLE
Update package.json and package-lock.json so test script warns on broken links

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "editorconfig-checker": "^4.0.2",
         "license-compatibility-checker": "^0.3.0",
         "licensee": "^10.0.0",
-        "markdown-link-check": "^3.10.3",
+        "markdown-link-check": "git+https://git@github.com/thebiggest0/markdown-link-check.git#2e03799c15954cc1f0d2a08adf4ffd17cf1447df",
         "markdownlint-cli": "^0.32.2",
         "site-validator-cli": "^1.3.5",
         "yaml": "^2.2.2"
@@ -3857,10 +3857,11 @@
       }
     },
     "node_modules/markdown-link-check": {
-      "version": "3.10.3",
-      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.10.3.tgz",
-      "integrity": "sha512-uGdJiZOy1CVWlRe7CyBSJ0Gz80Xm4vt++xjX9sNFjB7qcAxLinaMmzFQ5xOwERaXC9mK770BhnqnsyJT1gTr9w==",
+      "version": "3.10.4",
+      "resolved": "git+https://git@github.com/thebiggest0/markdown-link-check.git#2e03799c15954cc1f0d2a08adf4ffd17cf1447df",
+      "integrity": "sha512-Pw6qgD07RElrVe802dS1qfwAMnYg4dZ5FJCf8AAyz/TQSvVjFoIejY7INwytHcgk41jgVjdLz8SvkB3P3g/xNg==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "async": "^3.2.4",
         "chalk": "^4.1.2",
@@ -9405,10 +9406,10 @@
       }
     },
     "markdown-link-check": {
-      "version": "3.10.3",
-      "resolved": "https://registry.npmjs.org/markdown-link-check/-/markdown-link-check-3.10.3.tgz",
-      "integrity": "sha512-uGdJiZOy1CVWlRe7CyBSJ0Gz80Xm4vt++xjX9sNFjB7qcAxLinaMmzFQ5xOwERaXC9mK770BhnqnsyJT1gTr9w==",
+      "version": "git+https://git@github.com/thebiggest0/markdown-link-check.git#2e03799c15954cc1f0d2a08adf4ffd17cf1447df",
+      "integrity": "sha512-Pw6qgD07RElrVe802dS1qfwAMnYg4dZ5FJCf8AAyz/TQSvVjFoIejY7INwytHcgk41jgVjdLz8SvkB3P3g/xNg==",
       "dev": true,
+      "from": "markdown-link-check@git+https://git@github.com/thebiggest0/markdown-link-check.git#2e03799c15954cc1f0d2a08adf4ffd17cf1447df",
       "requires": {
         "async": "^3.2.4",
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "editorconfig-checker": "^4.0.2",
     "license-compatibility-checker": "^0.3.0",
     "licensee": "^10.0.0",
-    "markdown-link-check": "^3.10.3",
+    "markdown-link-check": "git+https://git@github.com/thebiggest0/markdown-link-check.git#2e03799c15954cc1f0d2a08adf4ffd17cf1447df",
     "markdownlint-cli": "^0.32.2",
     "site-validator-cli": "^1.3.5",
     "yaml": "^2.2.2"


### PR DESCRIPTION
Package.json
- Change devDependencies for mark-down-link from “^3..10.3” (https://github.com/tcort/markdown-link-check) to https://github.com/thebiggest0/markdown-link-check.
- Reason: To prevent an error from being thrown when a broken link is encountered, the javascript in markdown-link-check needed to be changed. And for the change to be retained for future use this was the solution I found.

Package-lock.json
- Update content to reflect changes made to package.json (through npm install).
- Changes: mark-down-link resolved points to https://github.com/thebiggest0/markdown-link-check instead of the original registry on http://npmjs.org/.
- Changes: The version is now 3.10.4 (before 3.10.3) to reflect the changes I made in the markdown-link-check file. In the function runMarkdownLinkCheck() in the if condition which checks for broken links I changed console.error to console.warn and removed resolve(), now promise does not fail when encountering a broken link.