### PR TITLE
Update markdown-link-check dependency and weekly link check test

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -13,4 +13,5 @@ jobs:
       uses: actions/setup-node@v4
       with:
         node-version: '14.x'
-    - run: npm weekly-link-check
+    - run: npm ci
+    - run: npm run weekly-link-check

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "editorconfig-checker": "^4.0.2",
         "license-compatibility-checker": "^0.3.0",
         "licensee": "^10.0.0",
-        "markdown-link-check": "git+https://git@github.com/thebiggest0/markdown-link-check.git#2e03799c15954cc1f0d2a08adf4ffd17cf1447df",
+        "markdown-link-check": "git+https://git@github.com/sara-sabr/markdown-link-check.git#af79d715c1929316806cdb6130a0a5be6a341683",
         "markdownlint-cli": "^0.32.2",
         "site-validator-cli": "^1.3.5",
         "yaml": "^2.2.2"
@@ -3858,8 +3858,8 @@
     },
     "node_modules/markdown-link-check": {
       "version": "3.10.4",
-      "resolved": "git+https://git@github.com/thebiggest0/markdown-link-check.git#2e03799c15954cc1f0d2a08adf4ffd17cf1447df",
-      "integrity": "sha512-Pw6qgD07RElrVe802dS1qfwAMnYg4dZ5FJCf8AAyz/TQSvVjFoIejY7INwytHcgk41jgVjdLz8SvkB3P3g/xNg==",
+      "resolved": "git+https://git@github.com/sara-sabr/markdown-link-check.git#af79d715c1929316806cdb6130a0a5be6a341683",
+      "integrity": "sha512-ddJlXIu0Ibb+kUsK8adzV8NBFcoqI68Ii51M4rpV6Q/lgLV4iJGgruym92s5eszPuhchrCI7tTPm047IHm3m2g==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
@@ -9406,10 +9406,10 @@
       }
     },
     "markdown-link-check": {
-      "version": "git+https://git@github.com/thebiggest0/markdown-link-check.git#2e03799c15954cc1f0d2a08adf4ffd17cf1447df",
-      "integrity": "sha512-Pw6qgD07RElrVe802dS1qfwAMnYg4dZ5FJCf8AAyz/TQSvVjFoIejY7INwytHcgk41jgVjdLz8SvkB3P3g/xNg==",
+      "version": "git+https://git@github.com/sara-sabr/markdown-link-check.git#af79d715c1929316806cdb6130a0a5be6a341683",
+      "integrity": "sha512-ddJlXIu0Ibb+kUsK8adzV8NBFcoqI68Ii51M4rpV6Q/lgLV4iJGgruym92s5eszPuhchrCI7tTPm047IHm3m2g==",
       "dev": true,
-      "from": "markdown-link-check@git+https://git@github.com/thebiggest0/markdown-link-check.git#2e03799c15954cc1f0d2a08adf4ffd17cf1447df",
+      "from": "markdown-link-check@git+https://git@github.com/sara-sabr/markdown-link-check.git#af79d715c1929316806cdb6130a0a5be6a341683",
       "requires": {
         "async": "^3.2.4",
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "editorconfig-checker": "^4.0.2",
     "license-compatibility-checker": "^0.3.0",
     "licensee": "^10.0.0",
-    "markdown-link-check": "git+https://git@github.com/thebiggest0/markdown-link-check.git#2e03799c15954cc1f0d2a08adf4ffd17cf1447df",
+    "markdown-link-check": "git+https://git@github.com/sara-sabr/markdown-link-check.git#af79d715c1929316806cdb6130a0a5be6a341683",
     "markdownlint-cli": "^0.32.2",
     "site-validator-cli": "^1.3.5",
     "yaml": "^2.2.2"


### PR DESCRIPTION
Package.json & Package-lock.json
- Update devDependencies in package.json to point to markdown-link-check GitHub repository in sara-sabr.
- Update package-lock.json according to package.json

GitHub actions: link-check.yml
- Add npm ci
- Update run: npm run weekly-link-check